### PR TITLE
devel: Adding support for network VLAN(s) information retrieval through ome_network_vlan_info module

### DIFF
--- a/library/dellemc/ome/ome_network_vlan_info.py
+++ b/library/dellemc/ome/ome_network_vlan_info.py
@@ -1,0 +1,262 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+#
+# Dell EMC OpenManage Ansible Modules
+# Version 2.1.3
+# Copyright (C) 2018-2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: ome_network_vlan_info
+short_description: Retrieves the information about networks VLAN(s) present in OpenManage Enterprise.
+version_added: "2.10.0"
+description:
+    This module allows to retrieve the following
+    - A list of all the network VLANs with their detailed information.
+    - Information about a specific network VLAN using VLAN I(id) or VLAN I(name).
+options:
+    hostname:
+        description: Target IP Address or hostname.
+        type: str
+        required: true
+    username:
+        description: Target username.
+        type: str
+        required: true
+    password:
+        description: Target user password.
+        type: str
+        required: true
+    port:
+        description: Target HTTPS port.
+        type: int
+        default: 443
+    id:
+        description:
+            - A unique identifier of the network VLAN available in the device,
+            - I(id) and I(name) are mutually exclusive.
+        type: int
+    name:
+        description:
+            - A unique name of the network VLAN available in the device.
+            - I(name) and I(id) are mutually exclusive.
+        type: str
+
+requirements:
+    - "python >= 2.7.5"
+author: "Deepak Joshi(@deepakjoshishri)"
+'''
+
+EXAMPLES = """
+---
+- name: Retrieve information about all network VLANs(s) available in the device.
+  ome_network_vlan_info:
+    hostname: "192.168.0.1"
+    username: "username"
+    password: "password"
+
+- name: Retrieve information about a network VLAN using the VLAN ID.
+  ome_network_vlan_info:
+    hostname: "192.168.0.1"
+    username: "username"
+    password: "password"
+    id: 12345
+
+- name: Retrieve information about a network VLAN using the VLAN name.
+  ome_network_vlan_info:
+    hostname: "192.168.0.1"
+    username: "username"
+    password: "password"
+    name: "Network VLAN - 1"
+"""
+
+RETURN = '''
+---
+msg:
+  type: dict
+  description: Detailed information of the network VLAN(s).
+  returned: success
+  sample: {
+  "msg": "Successfully retrieved the network VLAN information.",
+  "network_vlan_info": [
+        {
+            "CreatedBy": "admin",
+            "CreationTime": "2020-09-02 18:48:42.129",
+            "Description": "Description of Logical Network - 1",
+            "Id": 20057,
+            "InternalRefNWUUId": "42b9903d-93f8-4184-adcf-0772e4492f71",
+            "Name": "Network VLAN - 1",
+            "Type": {
+                "Description": "This is the network for general purpose traffic. QOS Priority : Bronze.",
+                "Id": 1,
+                "Name": "General Purpose (Bronze)",
+                "NetworkTrafficType": "Ethernet",
+                "QosType": {
+                    "Id": 4,
+                    "Name": "Bronze"
+                },
+                "VendorCode": "GeneralPurpose"
+            },
+            "UpdatedBy": null,
+            "UpdatedTime": "2020-09-02 18:48:42.129",
+            "VlanMaximum": 111,
+            "VlanMinimum": 111
+        },
+        {
+            "CreatedBy": "admin",
+            "CreationTime": "2020-09-02 18:49:11.507",
+            "Description": "Description of Logical Network - 2",
+            "Id": 20058,
+            "InternalRefNWUUId": "e46ccb3f-ef57-4617-ac76-46c56594005c",
+            "Name": "Network VLAN - 2",
+            "Type": {
+                "Description": "This is the network for general purpose traffic. QOS Priority : Silver.",
+                "Id": 2,
+                "Name": "General Purpose (Silver)",
+                "NetworkTrafficType": "Ethernet",
+                "QosType": {
+                    "Id": 3,
+                    "Name": "Silver"
+                },
+                "VendorCode": "GeneralPurpose"
+            },
+            "UpdatedBy": null,
+            "UpdatedTime": "2020-09-02 18:49:11.507",
+            "VlanMaximum": 112,
+            "VlanMinimum": 112
+        }
+    ]
+}
+error_info:
+  description: Details of the HTTP Error.
+  returned: on HTTP error
+  type: dict
+  sample: {
+    "error": {
+      "code": "Base.1.0.GeneralError",
+      "message": "A general error has occurred. See ExtendedInfo for more information.",
+      "@Message.ExtendedInfo": [
+        {
+          "MessageId": "GEN1234",
+          "RelatedProperties": [],
+          "Message": "Unable to process the request because an error occurred.",
+          "MessageArgs": [],
+          "Severity": "Critical",
+          "Resolution": "Retry the operation. If the issue persists, contact your system administrator."
+        }
+      ]
+    }
+  }
+'''
+
+import json
+from ssl import SSLError
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.remote_management.dellemc.ome import RestOME
+from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
+from ansible.module_utils.urls import ConnectionError, SSLValidationError
+
+# Base URI to fetch all logical networks information
+NETWORK_VLAN_BASE_URI = "NetworkConfigurationService/Networks"
+NETWORK_TYPE_BASE_URI = "NetworkConfigurationService/NetworkTypes"
+QOS_TYPE_BASE_URI = "NetworkConfigurationService/QosTypes"
+
+# Module Success Message
+MODULE_SUCCESS_MESSAGE = "Successfully retrieved the network VLAN information."
+
+# Module Failure Messages
+MODULE_FAILURE_MESSAGE = "Failed to retrieve the network VLAN information."
+NETWORK_VLAN_NAME_NOT_FOUND = "Provided network VLAN with name - '{0}' does not exist."
+
+
+def clean_data(data):
+    """
+    data: A dictionary.
+    return: A data dictionary after removing items that are not required for end user.
+    """
+    for k in ['@odata.id', '@odata.type', '@odata.context', '@odata.count']:
+        data.pop(k, None)
+    return data
+
+
+def get_network_type_and_qos_type_information(rest_obj, network_vlan):
+    """
+    rest_obj: Object containing information about connection to device.
+    network_vlan: A dictionary containing information of network VLAN.
+    return: updated dictionary with additional info for "Type" and "QosType" keys.
+    """
+    network_vlan = clean_data(network_vlan)
+    network_types_uri = "{0}({1})".format(NETWORK_TYPE_BASE_URI, network_vlan.get("Type"))
+    resp = rest_obj.invoke_request('GET', network_types_uri)
+    if resp.status_code == 200:
+        network_vlan['Type'] = clean_data(resp.json_data)
+        qos_type_uri = "{0}({1})".format(QOS_TYPE_BASE_URI, network_vlan.get("Type").get("QosType"))
+        resp = rest_obj.invoke_request('GET', qos_type_uri)
+        network_vlan['Type']['QosType'] = clean_data(resp.json_data) if resp.status_code == 200 else \
+            network_vlan['Type']['QosType']
+    return network_vlan
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            "hostname": {"required": True, "type": 'str'},
+            "username": {"required": True, "type": 'str'},
+            "password": {"required": True, "type": 'str', "no_log": True},
+            "port": {"required": False, "default": 443, "type": 'int'},
+            "id": {"required": False, "type": 'int'},
+            "name": {"required": False, "type": 'str'}
+        },
+        mutually_exclusive=[["id", "name"]],
+        supports_check_mode=False)
+    try:
+        with RestOME(module.params, req_session=True) as rest_obj:
+            # Form URI to fetch network VLAN information
+            network_vlan_uri = "{0}({1})".format(NETWORK_VLAN_BASE_URI, module.params.get("id")) if module.params.get(
+                "id") else NETWORK_VLAN_BASE_URI
+            resp = rest_obj.invoke_request('GET', network_vlan_uri)
+            if resp.status_code == 200:
+                network_vlan_info = resp.json_data.get('value') if isinstance(resp.json_data.get('value'), list) else [
+                    resp.json_data]
+                if module.params.get("name"):
+                    network_vlan_name = module.params.get("name")
+                    network_vlan = []
+                    for item in network_vlan_info:
+                        if item["Name"] == network_vlan_name.strip():
+                            network_vlan = [item]
+                            break
+                    if not network_vlan:
+                        module.fail_json(msg=NETWORK_VLAN_NAME_NOT_FOUND.format(network_vlan_name))
+                    network_vlan_info = network_vlan
+                complete_network_vlan_info = []
+                # Get network type and Qos Type information for each dict in list
+                for network_vlan in network_vlan_info:
+                    complete_network_vlan_info.append(get_network_type_and_qos_type_information(rest_obj, network_vlan))
+                module.exit_json(msg=MODULE_SUCCESS_MESSAGE, network_vlan_info=complete_network_vlan_info)
+            else:
+                module.fail_json(msg=MODULE_FAILURE_MESSAGE)
+    except HTTPError as err:
+        if err.getcode() == 404:
+            module.fail_json(msg=str(err))
+        module.fail_json(msg=str(MODULE_FAILURE_MESSAGE), error_info=json.load(err))
+    except URLError as err:
+        module.exit_json(msg=str(err), unreachable=True)
+    except (IOError, ValueError, SSLError, TypeError, KeyError, ConnectionError, SSLValidationError) as err:
+        module.fail_json(msg=str(err))
+
+
+if __name__ == '__main__':
+    main()

--- a/library/dellemc/ome/ome_network_vlan_info.py
+++ b/library/dellemc/ome/ome_network_vlan_info.py
@@ -86,7 +86,7 @@ EXAMPLES = """
 RETURN = '''
 ---
 msg:
-  type: dict
+  type: str
   description: Detailed information of the network VLAN(s).
   returned: success
   sample: {
@@ -181,6 +181,8 @@ MODULE_SUCCESS_MESSAGE = "Successfully retrieved the network VLAN information."
 MODULE_FAILURE_MESSAGE = "Failed to retrieve the network VLAN information."
 NETWORK_VLAN_NAME_NOT_FOUND = "Provided network VLAN with name - '{0}' does not exist."
 
+SAFE_MAX_LIMIT = 9999
+
 
 def clean_data(data):
     """
@@ -226,7 +228,7 @@ def main():
         with RestOME(module.params, req_session=True) as rest_obj:
             # Form URI to fetch network VLAN information
             network_vlan_uri = "{0}({1})".format(NETWORK_VLAN_BASE_URI, module.params.get("id")) if module.params.get(
-                "id") else NETWORK_VLAN_BASE_URI
+                "id") else "{0}?$top={1}".format(NETWORK_VLAN_BASE_URI, SAFE_MAX_LIMIT)
             resp = rest_obj.invoke_request('GET', network_vlan_uri)
             if resp.status_code == 200:
                 network_vlan_info = resp.json_data.get('value') if isinstance(resp.json_data.get('value'), list) else [

--- a/output/ome/ome_network_vlan_info.md
+++ b/output/ome/ome_network_vlan_info.md
@@ -1,0 +1,54 @@
+*Retrieve network vlan details.
+
+{
+  "msg": "Successfully retrieved the network VLAN information.",
+  "network_vlan_info": [
+    {
+      "CreatedBy": "admin",
+      "CreationTime": "2020-09-02 18:48:42.129",
+      "Description": "Description of Logical Network - 1",
+      "Id": 20057,
+      "InternalRefNWUUId": "42b9903d-93f8-4184-adcf-0772e4492f71",
+      "Name": "Network VLAN - 1",
+      "Type": {
+        "Description": "This is the network for general purpose traffic. QOS Priority : Bronze.",
+        "Id": 1,
+        "Name": "General Purpose (Bronze)",
+        "NetworkTrafficType": "Ethernet",
+        "QosType": {
+          "Id": 4,
+          "Name": "Bronze"
+        },
+        "VendorCode": "GeneralPurpose"
+      },
+      "UpdatedBy": null,
+      "UpdatedTime": "2020-09-02 18:48:42.129",
+      "VlanMaximum": 111,
+      "VlanMinimum": 111
+    },
+    {
+      "CreatedBy": "admin",
+      "CreationTime": "2020-09-02 18:49:11.507",
+      "Description": "Description of Logical Network - 2",
+      "Id": 20058,
+      "InternalRefNWUUId": "e46ccb3f-ef57-4617-ac76-46c56594005c",
+      "Name": "Network VLAN - 2",
+      "Type": {
+        "Description": "This is the network for general purpose traffic. QOS Priority : Silver.",
+        "Id": 2,
+        "Name": "General Purpose (Silver)",
+        "NetworkTrafficType": "Ethernet",
+        "QosType": {
+          "Id": 3,
+          "Name": "Silver"
+        },
+        "VendorCode": "GeneralPurpose"
+      },
+      "UpdatedBy": null,
+      "UpdatedTime": "2020-09-02 18:49:11.507",
+      "VlanMaximum": 112,
+      "VlanMinimum": 112
+    }
+  ]
+}
+

--- a/playbooks/ome/ome_network_vlan_info.yml
+++ b/playbooks/ome/ome_network_vlan_info.yml
@@ -1,0 +1,26 @@
+---
+- hosts: ome
+  connection: local
+  name: Dell OpenManage Ansible OpenManage Enterprise network vlan details.
+  gather_facts: False
+
+  tasks:
+    - name: Retrieve information about all network VLANs(s) available in the device.
+      ome_network_vlan_info:
+        hostname: "192.168.0.1"
+        username: "username"
+        password: "password"
+
+    - name: Retrieve information about a network VLAN using the VLAN ID.
+      ome_network_vlan_info:
+        hostname: "192.168.0.1"
+        username: "username"
+        password: "password"
+        id: 12345
+
+    - name: Retrieve information about a network VLAN using the VLAN name.
+      ome_network_vlan_info:
+        hostname: "192.168.0.1"
+        username: "username"
+        password: "password"
+        name: "Network VLAN - 1"

--- a/test/units/library/test_ome_network_vlan_info.py
+++ b/test/units/library/test_ome_network_vlan_info.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+
+#
+# Dell EMC OpenManage Ansible Modules
+# Version 2.1.3
+# Copyright (C) 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import pytest
+import json
+from ansible.modules.remote_management.dellemc import ome_network_vlan_info
+from units.modules.remote_management.dellemc.common import FakeAnsibleModule, Constants
+from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
+from ansible.module_utils.urls import ConnectionError, SSLValidationError
+from io import StringIO
+from ansible.module_utils._text import to_text
+
+MODULE_PATH = 'ansible.modules.remote_management.dellemc.'
+
+response = {
+    '@odata.context': '/api/$metadata#Collection(NetworkConfigurationService.Network)',
+    '@odata.count': 2,
+    'value': [
+        {
+            '@odata.type': '#NetworkConfigurationService.Network',
+            '@odata.id': '/api/NetworkConfigurationService/Networks(20057)',
+            'Id': 20057,
+            'Name': 'Logical Network - 1',
+            'Description': 'Description of Logical Network - 1',
+            'VlanMaximum': 111,
+            'VlanMinimum': 111,
+            'Type': 1,
+            'CreatedBy': 'admin',
+            'CreationTime': '2020-09-02 18:48:42.129',
+            'UpdatedBy': None,
+            'UpdatedTime': '2020-09-02 18:48:42.129',
+            'InternalRefNWUUId': '42b9903d-93f8-4184-adcf-0772e4492f71'
+        },
+        {
+            '@odata.type': '#NetworkConfigurationService.Network',
+            '@odata.id': '/api/NetworkConfigurationService/Networks(20058)',
+            'Id': 20058,
+            'Name': 'Logical Network - 2',
+            'Description': 'Description of Logical Network - 2',
+            'VlanMaximum': 112,
+            'VlanMinimum': 112,
+            'Type': 2,
+            'CreatedBy': 'admin',
+            'CreationTime': '2020-09-02 18:49:11.507',
+            'UpdatedBy': None,
+            'UpdatedTime': '2020-09-02 18:49:11.507',
+            'InternalRefNWUUId': 'e46ccb3f-ef57-4617-ac76-46c56594005c'
+        }
+    ]
+}
+
+
+class TestOmeNetworkVlanInfo(FakeAnsibleModule):
+    """Pytest class for ome_network_vlan_info module."""
+    module = ome_network_vlan_info
+
+    @pytest.fixture
+    def ome_connection_network_vlan_info_mock(self, mocker, ome_response_mock):
+        connection_class_mock = mocker.patch(
+            'ansible_collections.dellemc.openmanage.plugins.modules.ome_network_vlan_info.RestOME')
+        ome_connection_mock_obj = connection_class_mock.return_value.__enter__.return_value
+        ome_connection_mock_obj.invoke_request.return_value = ome_response_mock
+        return ome_connection_mock_obj
+
+    def test_get_network_vlan_info_success_case(self, ome_default_args, ome_connection_network_vlan_info_mock,
+                                                ome_response_mock):
+        ome_response_mock.json_data = response
+        ome_response_mock.status_code = 200
+        result = self._run_module(ome_default_args)
+        assert 'network_vlan_info' in result
+        assert result['msg'] == "Successfully retrieved the network VLAN information."
+
+    def test_get_network_vlan_info_by_id_success_case(self, mocker, ome_default_args,
+                                                      ome_connection_network_vlan_info_mock, ome_response_mock):
+        ome_default_args.update({"id": 20057})
+        ome_response_mock.success = True
+        ome_response_mock.json_data = response
+        ome_response_mock.status_code = 200
+        result = self._run_module(ome_default_args)
+        assert result['changed'] is False
+        assert 'network_vlan_info' in result
+        assert result['msg'] == "Successfully retrieved the network VLAN information."
+
+    def test_get_network_vlan_info_by_name_success_case(self, mocker, ome_default_args,
+                                                        ome_connection_network_vlan_info_mock, ome_response_mock):
+        ome_default_args.update({"name": "Logical Network - 1"})
+        ome_response_mock.success = True
+        ome_response_mock.json_data = response
+        ome_response_mock.status_code = 200
+        result = self._run_module(ome_default_args)
+        assert result['changed'] is False
+        assert 'network_vlan_info' in result
+        assert result['msg'] == "Successfully retrieved the network VLAN information."
+
+    def test_network_vlan_info_failure_case(self, ome_default_args, ome_connection_network_vlan_info_mock,
+                                            ome_response_mock):
+        ome_response_mock.status_code = 500
+        result = self._run_module_with_fail_json(ome_default_args)
+        assert result['msg'] == "Failed to retrieve the network VLAN information."
+
+    def test_network_vlan_info_name_failure_case(self, ome_default_args, ome_connection_network_vlan_info_mock,
+                                                 ome_response_mock):
+        ome_default_args.update({"name": "non-existing vlan"})
+        ome_response_mock.success = True
+        ome_response_mock.json_data = response
+        ome_response_mock.status_code = 200
+        result = self._run_module_with_fail_json(ome_default_args)
+        assert result['failed'] is True
+        assert 'network_vlan_info' not in result
+        assert result['msg'] == "Provided network VLAN with name - 'non-existing vlan' does not exist."
+
+    @pytest.mark.parametrize("exc_type", [URLError, HTTPError, SSLValidationError, ConnectionError,
+                                          TypeError, ValueError])
+    def test_network_vlan_info_info_main_exception_case(self, exc_type, mocker, ome_default_args,
+                                                        ome_connection_network_vlan_info_mock, ome_response_mock):
+        ome_response_mock.status_code = 404
+        ome_response_mock.success = False
+        json_str = to_text(json.dumps({"data": "out"}))
+        if exc_type == URLError:
+            ome_connection_network_vlan_info_mock.invoke_request.side_effect = exc_type(
+                "ansible.module_utils.urls.open_url error")
+            result = self._run_module(ome_default_args)
+            assert result["unreachable"] is True
+        elif exc_type == HTTPError:
+            ome_connection_network_vlan_info_mock.invoke_request.side_effect = exc_type(
+                'http://testhost.com', 400, '<400 bad request>', {"accept-type": "application/json"},
+                StringIO(json_str))
+            result = self._run_module_with_fail_json(ome_default_args)
+            assert result['failed'] is True
+            assert 'msg' in result
+            assert 'error_info' in result
+
+            ome_connection_network_vlan_info_mock.invoke_request.side_effect = exc_type(
+                'http://testhost.com', 404, '<404 not found>', {"accept-type": "application/json"}, StringIO(json_str))
+            result = self._run_module_with_fail_json(ome_default_args)
+            assert result['failed'] is True
+            assert 'msg' in result
+        elif exc_type != SSLValidationError:
+            mocker.patch(MODULE_PATH + 'ome_network_vlan_info.get_network_type_and_qos_type_information',
+                         side_effect=exc_type('test'))
+            result = self._run_module_with_fail_json(ome_default_args)
+            assert result['failed'] is True
+            assert 'msg' in result
+        else:
+            mocker.patch(MODULE_PATH + 'ome_network_vlan_info.get_network_type_and_qos_type_information',
+                         side_effect=exc_type('http://testhost.com', 404, 'http error message',
+                                              {"accept-type": "application/json"}, StringIO(json_str)))
+            result = self._run_module_with_fail_json(ome_default_args)
+            assert result['failed'] is True
+            assert 'msg' in result

--- a/test/units/library/test_ome_network_vlan_info.py
+++ b/test/units/library/test_ome_network_vlan_info.py
@@ -78,7 +78,7 @@ class TestOmeNetworkVlanInfo(FakeAnsibleModule):
     @pytest.fixture
     def ome_connection_network_vlan_info_mock(self, mocker, ome_response_mock):
         connection_class_mock = mocker.patch(
-            'ansible_collections.dellemc.openmanage.plugins.modules.ome_network_vlan_info.RestOME')
+            'ansible.modules.remote_management.dellemc.ome_network_vlan_info.RestOME')
         ome_connection_mock_obj = connection_class_mock.return_value.__enter__.return_value
         ome_connection_mock_obj.invoke_request.return_value = ome_response_mock
         return ome_connection_mock_obj

--- a/test/units/library/test_ome_network_vlan_info.py
+++ b/test/units/library/test_ome_network_vlan_info.py
@@ -25,7 +25,7 @@ MODULE_PATH = 'ansible.modules.remote_management.dellemc.'
 
 response = {
     '@odata.context': '/api/$metadata#Collection(NetworkConfigurationService.Network)',
-    '@odata.count': 2,
+    '@odata.count': 1,
     'value': [
         {
             '@odata.type': '#NetworkConfigurationService.Network',
@@ -35,30 +35,40 @@ response = {
             'Description': 'Description of Logical Network - 1',
             'VlanMaximum': 111,
             'VlanMinimum': 111,
-            'Type': 1,
+            "Type": 1,
             'CreatedBy': 'admin',
             'CreationTime': '2020-09-02 18:48:42.129',
             'UpdatedBy': None,
             'UpdatedTime': '2020-09-02 18:48:42.129',
             'InternalRefNWUUId': '42b9903d-93f8-4184-adcf-0772e4492f71'
-        },
-        {
-            '@odata.type': '#NetworkConfigurationService.Network',
-            '@odata.id': '/api/NetworkConfigurationService/Networks(20058)',
-            'Id': 20058,
-            'Name': 'Logical Network - 2',
-            'Description': 'Description of Logical Network - 2',
-            'VlanMaximum': 112,
-            'VlanMinimum': 112,
-            'Type': 2,
-            'CreatedBy': 'admin',
-            'CreationTime': '2020-09-02 18:49:11.507',
-            'UpdatedBy': None,
-            'UpdatedTime': '2020-09-02 18:49:11.507',
-            'InternalRefNWUUId': 'e46ccb3f-ef57-4617-ac76-46c56594005c'
         }
     ]
 }
+
+network_type_qos_type_dict_reponse = {1: {'Id': 1, 'Name': 'General Purpose (Bronze)',
+                                          'Description':
+                                              'This is the network for general purpose traffic. QOS Priority : Bronze.',
+                                          'VendorCode': 'GeneralPurpose', 'NetworkTrafficType': 'Ethernet',
+                                          'QosType': {'Id': 4, 'Name': 'Bronze'}}}
+
+network_type_dict_response = {1: {'Id': 1, 'Name': 'General Purpose (Bronze)',
+                                  'Description':
+                                      'This is the network for general purpose traffic. QOS Priority : Bronze.',
+                                  'VendorCode': 'GeneralPurpose', 'NetworkTrafficType': 'Ethernet',
+                                  'QosType': 4}}
+
+qos_type_dict_response = {4: {'Id': 4, 'Name': 'Bronze'}}
+
+type_dict_ome_reponse = {'@odata.context': '/api/$metadata#Collection(NetworkConfigurationService.Network)',
+                         '@odata.count': 1,
+                         'value': [
+                             {'@odata.type': '#NetworkConfigurationService.NetworkType',
+                              '@odata.id': '/api/NetworkConfigurationService/NetworkTypes(1)',
+                              'Id': 1,
+                              'Name': 'General Purpose (Bronze)',
+                              'Description': 'This is the network for general purpose traffic. QOS Priority : Bronze.',
+                              'VendorCode': 'GeneralPurpose', 'NetworkTrafficType': 'Ethernet',
+                              'QosType': 4}]}
 
 
 class TestOmeNetworkVlanInfo(FakeAnsibleModule):
@@ -73,11 +83,15 @@ class TestOmeNetworkVlanInfo(FakeAnsibleModule):
         ome_connection_mock_obj.invoke_request.return_value = ome_response_mock
         return ome_connection_mock_obj
 
-    def test_get_network_vlan_info_success_case(self, ome_default_args, ome_connection_network_vlan_info_mock,
+    def test_get_network_vlan_info_success_case(self, mocker, ome_default_args, ome_connection_network_vlan_info_mock,
                                                 ome_response_mock):
         ome_response_mock.json_data = response
         ome_response_mock.status_code = 200
+        mocker.patch(
+            MODULE_PATH + 'ome_network_vlan_info.get_network_type_and_qos_type_information',
+            return_value=network_type_qos_type_dict_reponse)
         result = self._run_module(ome_default_args)
+        print(result)
         assert 'network_vlan_info' in result
         assert result['msg'] == "Successfully retrieved the network VLAN information."
 
@@ -87,6 +101,9 @@ class TestOmeNetworkVlanInfo(FakeAnsibleModule):
         ome_response_mock.success = True
         ome_response_mock.json_data = response
         ome_response_mock.status_code = 200
+        mocker.patch(
+            MODULE_PATH + 'ome_network_vlan_info.get_network_type_and_qos_type_information',
+            return_value=network_type_qos_type_dict_reponse)
         result = self._run_module(ome_default_args)
         assert result['changed'] is False
         assert 'network_vlan_info' in result
@@ -98,10 +115,27 @@ class TestOmeNetworkVlanInfo(FakeAnsibleModule):
         ome_response_mock.success = True
         ome_response_mock.json_data = response
         ome_response_mock.status_code = 200
+        mocker.patch(
+            MODULE_PATH + 'ome_network_vlan_info.get_network_type_and_qos_type_information',
+            return_value=network_type_qos_type_dict_reponse)
         result = self._run_module(ome_default_args)
         assert result['changed'] is False
         assert 'network_vlan_info' in result
         assert result['msg'] == "Successfully retrieved the network VLAN information."
+
+    def test_get_network_type_and_qos_type_information(self, mocker, ome_connection_network_vlan_info_mock):
+        mocker.patch(MODULE_PATH + 'ome_network_vlan_info.get_type_information',
+                     side_effect=[network_type_dict_response, qos_type_dict_response])
+        result = self.module.get_network_type_and_qos_type_information(ome_connection_network_vlan_info_mock)
+        assert result[1]['QosType']['Id'] == 4
+
+    def test_get_type_information(self, mocker, ome_default_args,
+                                  ome_connection_network_vlan_info_mock, ome_response_mock):
+        ome_response_mock.success = True
+        ome_response_mock.json_data = type_dict_ome_reponse
+        ome_response_mock.status_code = 200
+        result = self.module.get_type_information(ome_connection_network_vlan_info_mock, '')
+        assert result[1]['QosType'] == 4
 
     def test_network_vlan_info_failure_case(self, ome_default_args, ome_connection_network_vlan_info_mock,
                                             ome_response_mock):


### PR DESCRIPTION
### Addition of this module allows users to retrieve information about network VLAN(s) from OpenManage Enterprise and OpenManage Enterprise Modular through ansible.

PR contains the module, an example playbook, a sample output file, and a unit test script.

Unit-test code coverage of _96%_ as reported by command: `ansible-test coverage report`

Sanity tests are performed and tested as pass, using the command:  `ansible-test sanity --docker default <file_path>`

**Test Environments:**
```
- Ansible 2.9.14

- OpenManage Enterprise 3.4.1 and OpenManage Enterprise Modular v1.20.10

- OS: RHEL 8.2, Ubuntu 20.04

- Python 2.7.15 and Python 3.8.5 virtual environments
```

Signed-off-by: Deepak Joshi <deepak_joshi5@dell.com> <deepakjoshishri@gmail.com>