### PR TITLE
Change wording for shutdown_type to make clear what the options mean

### DIFF
--- a/docs/modules/idrac_server_config_profile.rst
+++ b/docs/modules/idrac_server_config_profile.rst
@@ -79,11 +79,11 @@ Parameters
   shutdown_type (optional, str, Graceful)
     This option is applicable for ``import`` command.
 
-    If ``Graceful``, it gracefully shuts down the server.
+    If ``Graceful``, it gracefully shuts down the server if needed.
 
     If ``Forced``,  it forcefully shuts down the server.
 
-    If ``NoReboot``, it does not reboot the server.
+    If ``NoReboot``, the job that applies the scp will pause until you manually reboot the server.
 
 
   end_host_power_state (optional, str, On)

--- a/plugins/modules/idrac_server_config_profile.py
+++ b/plugins/modules/idrac_server_config_profile.py
@@ -70,9 +70,9 @@ options:
   shutdown_type:
     description:
       - This option is applicable for C(import) command.
-      - If C(Graceful), it gracefully shuts down the server.
+      - If C(Graceful), it gracefully shuts down the server if needed.
       - If C(Forced),  it forcefully shuts down the server.
-      - If C(NoReboot), it does not reboot the server.
+      - If C(NoReboot), the job that applies the scp will pause until you manually reboot the server.
     type: str
     choices: ['Graceful', 'Forced', 'NoReboot']
     default: 'Graceful'


### PR DESCRIPTION
##### SUMMARY
So the options for shutdown_type are a little confusing -- `NoReboot` does not actually mean no reboot, but it means you have to manually reboot the server even if the scp operation could be applied without a reboot. Shutdown type `Graceful` actually means it will shut down the server graceful _if needed_ I am not yet sure if `Forced` also only reboots if needed - I don't have any servers to test that I actually want to reboot right now :)

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
`idrac_server_config_profile`

##### ISSUES


##### OUTPUT


##### ADDITIONAL INFORMATION
