### PR TITLE
dellemc_idrac_storage_volume: Fix documentation

### DIFF
--- a/plugins/modules/dellemc_idrac_storage_volume.py
+++ b/plugins/modules/dellemc_idrac_storage_volume.py
@@ -114,8 +114,8 @@ options:
       - >-
         This option represents whether a reset config operation needs to be performed on the RAID controller.
         Reset Config operation deletes all the virtual disks present on the RAID controller.
-    choices: [True, False]
-    default: False
+    choices: ['True', 'False']
+    default: 'False'
   raid_init_operation:
     type: str
     description: This option represents initialization configuration operation to be performed on the virtual disk.


### PR DESCRIPTION
##### SUMMARY
The sanity tests against ansible-core devel started to fail 2 or 3 days ago. Might be because of [this](https://github.com/ansible-collections/news-for-maintainers/issues/9#issuecomment-1071373823) although I'm not really sure.

Anyway, this PR should fix it.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
dellemc_idrac_storage_volume

##### ISSUES

##### OUTPUT

##### ADDITIONAL INFORMATION
_All_ unit tests fail, too. This is a bit annoying. I don't really understand why, but maybe I'll find the time to work on this. I won't promise anything, though ;-)

BTW: It looks like you test with ansible (core) 2.10, 2.11 and devel. Maybe you should add 2.12 to the list. On the other hand, you might consider removing 2.10 (which will be EOL in two months, together with 2.9). Just an idea :-)