### PR TITLE
Fix Report when selecting a single device

### DIFF
--- a/plugins/modules/ome_configuration_compliance_info.py
+++ b/plugins/modules/ome_configuration_compliance_info.py
@@ -199,7 +199,9 @@ def compliance_report(module, rest_obj):
                                  "there is no template associated with the baseline.")
         device_id = validate_device(module, rest_obj, device_id=device_id,
                                     service_tag=device_service_tag, base_id=baseline_id)
-        report = list(filter(lambda d: d['Id'] in [device_id], baseline_report.json_data["value"]))
+        compliance_uri = COMPLIANCE_URI.format(baseline_id, device_id)
+        attr_group = rest_obj.invoke_request("GET", compliance_uri)
+        return attr_group.json_data.get("ComplianceAttributeGroups")
     else:
         report = baseline_report.json_data.get("value")
     device_compliance = report


### PR DESCRIPTION
##### SUMMARY
after checking the device id, we can directly get the report for the device instead of getting the whole report and then looping through all the devices.

Fixes #425

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ome_configuration_compliance_info

##### ISSUES
if more than 20 devices in a group, it's not working when selecting a single device

##### OUTPUT
<!--- Paste the functionality test result below -->
```
TASK [Retrieve compliance report for baseline] ***************************************************************************************************
ok: [server1-> localhost]

TASK [debug] *************************************************************************************************************************************
ok: [server1] => (item=BIOS) => {
    "msg": "3"
}
ok: [server1] => (item=NIC) => {
    "msg": "2"
}

```