### PR TITLE
fix attr_id extraction in fetch_idrac_uri_attr

### DIFF
--- a/plugins/modules/idrac_attributes.py
+++ b/plugins/modules/idrac_attributes.py
@@ -427,7 +427,7 @@ def fetch_idrac_uri_attr(idrac, module, res_id):
     if dell_attributes:
         for item in dell_attributes:
             uri = item.get('@odata.id')
-            attr_id = uri.split("/")[-1]
+            attr_id = uri.split("/")[-2]
             uri_dict[attr_id] = uri
         idrac_attr = module.params.get("idrac_attributes")
         system_attr = module.params.get("system_attributes")


### PR DESCRIPTION
# Description

Found a bug in idrac_attributes module.

attr_id was not extracted properly in fetch_idrac_uri_attr so we ended with following exception:

```
Traceback (most recent call last):
  File "/Users/nmiletic/.ansible/tmp/ansible-tmp-1666180497.074697-63408-81263906993044/debug_dir/ansible_collections/dellemc/openmanage/plugins/modules/idrac_attributes.py", line 512, in main
    diff, uri_dict, idrac_response_attr, system_response_attr, lc_response_attr = fetch_idrac_uri_attr(idrac, module, res_id)
  File "/Users/nmiletic/.ansible/tmp/ansible-tmp-1666180497.074697-63408-81263906993044/debug_dir/ansible_collections/dellemc/openmanage/plugins/modules/idrac_attributes.py", line 439, in fetch_idrac_uri_attr
    x, idrac_response_attr = get_response_attr(idrac, MANAGER_ID, idrac_attr, uri_dict)
  File "/Users/nmiletic/.ansible/tmp/ansible-tmp-1666180497.074697-63408-81263906993044/debug_dir/ansible_collections/dellemc/openmanage/plugins/modules/idrac_attributes.py", line 366, in get_response_attr
    response = idrac.invoke_request(uri_dict.get(idrac_id), "GET")
  File "/Users/nmiletic/.ansible/tmp/ansible-tmp-1666180497.074697-63408-81263906993044/debug_dir/ansible_collections/dellemc/openmanage/plugins/module_utils/idrac_redfish.py", line 172, in invoke_request
    resp = open_url(url, data=data, **url_kwargs)
  File "/Users/nmiletic/.ansible/tmp/ansible-tmp-1666180497.074697-63408-81263906993044/debug_dir/ansible/module_utils/urls.py", line 1575, in open_url
    return Request().open(method, url, data=data, headers=headers, use_proxy=use_proxy,
  File "/Users/nmiletic/.ansible/tmp/ansible-tmp-1666180497.074697-63408-81263906993044/debug_dir/ansible/module_utils/urls.py", line 1361, in open
    elif '@' in parsed.netloc:
TypeError: a bytes-like object is required, not 'str'
```


Example of the issue before and after fix:
```
>>> uri = '/redfish/v1/Managers/iDRAC.Embedded.1/Attributes'
>>> uri.split("/")[-1]
'Attributes'
>>> uri.split("/")
['', 'redfish', 'v1', 'Managers', 'iDRAC.Embedded.1', 'Attributes']
>>> uri.split("/")[-2]
'iDRAC.Embedded.1'
```

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
idrac_attributes module

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below

```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
>>> uri = '/redfish/v1/Managers/iDRAC.Embedded.1/Attributes'
>>> uri.split("/")[-1]
'Attributes'
>>> uri.split("/")
['', 'redfish', 'v1', 'Managers', 'iDRAC.Embedded.1', 'Attributes']
>>> uri.split("/")[-2]
'iDRAC.Embedded.1'
```
