### PR TITLE
Fix non-matching defaults in docs

### DIFF
--- a/plugins/modules/ome_firmware.py
+++ b/plugins/modules/ome_firmware.py
@@ -61,6 +61,7 @@ options:
       - This is applicable to I(device_service_tag), I(device_id), and I(baseline_name).
     type: list
     elements: str
+    default: []
   devices:
     description:
       - This option allows to select components on each device for firmware update.
@@ -81,6 +82,7 @@ options:
       components:
         description: The target components to be updated. If not specified, all applicable device components are considered.
         type: list
+        default: []
         elements: str
   schedule:
     type: str

--- a/plugins/modules/ome_user.py
+++ b/plugins/modules/ome_user.py
@@ -236,7 +236,7 @@ def main():
                   "choices": ['present', 'absent']},
         "user_id": {"required": False, "type": 'int'},
         "name": {"required": False, "type": 'str'},
-        "attributes": {"required": False, "type": 'dict'},
+        "attributes": {"required": False, "type": 'dict', "default": {}},
     }
     specs.update(ome_auth_params)
     module = AnsibleModule(
@@ -247,8 +247,6 @@ def main():
 
     try:
         _validate_inputs(module)
-        if module.params.get("attributes") is None:
-            module.params["attributes"] = {}
         with RestOME(module.params, req_session=True) as rest_obj:
             method, path, payload = _get_resource_parameters(module, rest_obj)
             resp = rest_obj.invoke_request(method, path, data=payload)


### PR DESCRIPTION
# Description
Fix various non-matching `default` values exposed by ansible/ansible#79267.

I think my changes to `ome_firmware` are OK. I'm not sure about`ome_user`, though. Instead of changing the documentation, I've changed the argument spec. After all, it looks like you're just doing this manually:

https://github.com/dell/dellemc-openmanage-ansible-modules/blob/a580610b382b413280c2331c0db73950d397be0c/plugins/modules/ome_user.py#L250-L251

But I might be wrong there, maybe there's a good reason why you do it this way.

# GitHub Issues
None, as far as I can see.

# ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ome_firmware
ome_user

##### OUTPUT

##### ADDITIONAL INFORMATION
I think you're pretty good. I've seen 20+ issues in 9 or 10 modules in `community.vmware`. 3 issues in 2 modules is _nothing_ :-)

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility