### PR TITLE
Add link to module idrac_boot in the documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ You may obtain a copy of the License at
 - [dellemc_system_lockdown_mode](modules/dellemc_system_lockdown_mode.rst)
 - [idrac_attributes](modules/idrac_attributes.rst)
 - [idrac_bios](modules/idrac_bios.rst)
+- [idrac_boot](modules/idrac_boot.rst)
 - [idrac_certificates](modules/idrac_certificates.rst)
 - [idrac_firmware](modules/idrac_firmware.rst)
 - [idrac_firmware_info](modules/idrac_firmware_info.rst)


### PR DESCRIPTION
# Description

The link to module `idrac_boot` is missing from https://github.com/dell/dellemc-openmanage-ansible-modules/tree/collections/docs

# ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

`idrac_boot`

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility