### PR TITLE
Make ome_inventory module options available via environment variables

### DIFF
--- a/plugins/inventory/ome_inventory.py
+++ b/plugins/inventory/ome_inventory.py
@@ -2,7 +2,7 @@
 
 #
 # Dell OpenManage Ansible Modules
-# Version 7.2.0
+# Version 7.4.0
 # Copyright (C) 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -18,9 +18,52 @@ name: ome_inventory
 short_description: Group inventory plugin on OpenManage Enterprise.
 description: This plugin allows to retrieve inventory hosts from groups on OpenManage Enterprise.
 version_added: "7.1.0"
-extends_documentation_fragment:
-  - dellemc.openmanage.ome_auth_options
 options:
+  hostname:
+    description:
+    - OpenManage Enterprise or OpenManage Enterprise Modular IP address or hostname.
+    - If the value is not specified in the task, the value of environment variable C(OME_HOSTNAME) will be used instead.
+    env:
+     - name: OME_HOSTNAME
+    type: str
+    required: True
+  username:
+    description:
+    - OpenManage Enterprise or OpenManage Enterprise Modular username.
+    - If the value is not specified in the task, the value of environment variable C(OME_USERNAME) will be used instead.
+    env:
+     - name: OME_USERNAME
+    type: str
+    required: True
+  password:
+    description:
+    - OpenManage Enterprise or OpenManage Enterprise Modular password.
+    - If the value is not specified in the task, the value of environment variable C(OME_PASSWORD) will be used instead.
+    env:
+    - name: OME_PASSWORD
+    type: str
+    required: True
+  port:
+    description:
+    - OpenManage Enterprise or OpenManage Enterprise Modular HTTPS port.
+    - If the value is not specified in the task, the value of environment variable C(OME_PORT) will be used instead.
+    type: int
+    default: 443
+  validate_certs:
+    description:
+    - If C(False), the SSL certificates will not be validated.
+    - Configure C(False) only on personally controlled sites where self-signed certificates are used.
+    - Prior to collection version C(5.0.0), the I(validate_certs) is C(False) by default.
+    type: bool
+    default: True
+  ca_path:
+    description:
+    - The Privacy Enhanced Mail (PEM) file that contains a CA certificate to be used for the validation.
+    type: path
+  timeout:
+    description: The socket level timeout in seconds.
+    type: int
+    default: 30
   ome_group_name:
     description: Group name.
     type: str
@@ -96,12 +139,12 @@ class InventoryModule(BaseInventoryPlugin):
         self.config = None
 
     def _get_connection_resp(self):
-        port = self.config.get("port") if "port" in self.config else 443
-        validate_certs = self.config.get("validate_certs") if "validate_certs" in self.config else False
-        module_params = {"hostname": self.config.get("hostname"), "username": self.config.get("username"),
-                         "password": self.config.get("password"), "port": port, "validate_certs": validate_certs}
+        port = self.get_option("port") if "port" in self.config else 443
+        validate_certs = self.get_option("validate_certs") if "validate_certs" in self.config else False
+        module_params = {"hostname": self.get_option("hostname"), "username": self.get_option("username"),
+                         "password": self.get_option("password"), "port": port, "validate_certs": validate_certs}
         if "ca_path" in self.config:
-            module_params.update({"ca_path": self.config.get("ca_path")})
+            module_params.update({"ca_path": self.get_option("ca_path")})
         with RestOME(module_params, req_session=False) as ome:
             resp = ome.invoke_request("GET", GROUP_API)
         return resp.json_data
@@ -111,14 +154,14 @@ class InventoryModule(BaseInventoryPlugin):
         self.inventory.set_variable(host, "baseuri", host)
         self.inventory.set_variable(host, "hostname", host)
         if "host_vars" in self.config:
-            host_vars = self.config.get("host_vars")
+            host_vars = self.get_option("host_vars")
             for key, val in dict(host_vars).items():
                 self.inventory.set_variable(host, key, val)
 
     def _set_group_vars(self, group):
         self.inventory.add_group(group)
         if "group_vars" in self.config:
-            group_vars = self.config.get("group_vars")
+            group_vars = self.get_option("group_vars")
             if group in dict(group_vars):
                 for key, val in dict(dict(group_vars)[group]).items():
                     self.inventory.set_variable(group, key, val)
@@ -126,12 +169,12 @@ class InventoryModule(BaseInventoryPlugin):
     def _get_all_devices(self, device_uri):
         device_host = []
         device_host_uri = device_uri.strip("/api/")
-        port = self.config.get("port") if "port" in self.config else 443
-        validate_certs = self.config.get("validate_certs") if "validate_certs" in self.config else False
-        module_params = {"hostname": self.config.get("hostname"), "username": self.config.get("username"),
-                         "password": self.config.get("password"), "port": port, "validate_certs": validate_certs}
+        port = self.get_option("port") if "port" in self.config else 443
+        validate_certs = self.get_option("validate_certs") if "validate_certs" in self.config else False
+        module_params = {"hostname": self.get_option("hostname"), "username": self.get_option("username"),
+                         "password": self.get_option("password"), "port": port, "validate_certs": validate_certs}
         if "ca_path" in self.config:
-            module_params.update({"ca_path": self.config.get("ca_path")})
+            module_params.update({"ca_path": self.get_option("ca_path")})
         with RestOME(module_params, req_session=False) as ome:
             device_resp = ome.invoke_request("GET", device_host_uri)
             device_data = device_resp.json_data.get("value")
@@ -150,12 +193,12 @@ class InventoryModule(BaseInventoryPlugin):
         return device_host
 
     def _set_child_group(self, group_data):
-        port = self.config.get("port") if "port" in self.config else 443
-        validate_certs = self.config.get("validate_certs") if "validate_certs" in self.config else False
-        module_params = {"hostname": self.config.get("hostname"), "username": self.config.get("username"),
-                         "password": self.config.get("password"), "port": port, "validate_certs": validate_certs}
+        port = self.get_option("port") if "port" in self.config else 443
+        validate_certs = self.get_option("validate_certs") if "validate_certs" in self.config else False
+        module_params = {"hostname": self.get_option("hostname"), "username": self.get_option("username"),
+                         "password": self.get_option("password"), "port": port, "validate_certs": validate_certs}
         if "ca_path" in self.config:
-            module_params.update({"ca_path": self.config.get("ca_path")})
+            module_params.update({"ca_path": self.get_option("ca_path")})
         with RestOME(module_params, req_session=False) as ome:
             for gdata in group_data:
                 group_name = gdata["Name"]
@@ -185,7 +228,7 @@ class InventoryModule(BaseInventoryPlugin):
 
     def _populate(self, inventory_data):
         group_data = inventory_data.get("value")
-        group_name = str(self.config.get("ome_group_name")) if "ome_group_name" in self.config else None
+        group_name = str(self.get_option("ome_group_name")) if "ome_group_name" in self.config else None
         if group_name is not None:
             group_data = list(filter(lambda d: d.get("Name").lower() in [group_name.lower()], group_data))
         elif group_name is None:


### PR DESCRIPTION
Signed-off-by: Jesse Harris zigford@gmail.com

#### Description
To make some module parameters available as environment variables.

#### GitHub Issues
#480 

#### ISSUE TYPE
* Feature Pull Request

##### COMPONENT NAME
ome_inventory

##### OUTPUT

```paste below
$ export OME_USER=admin
$ export OME_PASSWORD=supersecretpass
$ export OME_HOST=dell-ome01.example.com

$ cat inventory.yml
---

plugin: dellemc.openmanage.ome_inventory
validate_certs: false

$ ansible-inventory -i inventory.yml --list
{
    "All Devices": {
        "children": [
            "Plugin Groups",
            "System Groups",
            "Custom Groups"
        ],
        "hosts": [
            "192.168.0.181",
         ]
    }
}

```