### PR TITLE
Custom idrac user privileges

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           # it is just required to run that once as "ansible-test sanity" in the docker image
           # will run on all python versions it supports.
-          python-version: 3.9
+          python-version: 3.10.12
 
       - name: Install ansible (${{ matrix.ansible-version }}) version
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible-version }}.tar.gz --disable-pip-version-check

--- a/changelogs/fragments/idra_user-custom_privilege.yaml
+++ b/changelogs/fragments/idra_user-custom_privilege.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - idrac_user - Add `custom_privilges` parameter to define custom priviliges instead of only relying on pre-defined roles.

--- a/docs/modules/idrac_user.rst
+++ b/docs/modules/idrac_user.rst
@@ -66,6 +66,12 @@ Parameters
 
     A user with ``None``, no privileges assigned.
 
+    Will be ignored, if custom_privilege parameter is provided.
+
+
+  custom_privilege (optional, int, None)
+    The privilege level assigned to the user.
+
 
   ipmi_lan_privilege (optional, str, None)
     The Intelligent Platform Management Interface LAN privilege level assigned to the user.

--- a/plugins/modules/idrac_user.py
+++ b/plugins/modules/idrac_user.py
@@ -3,8 +3,8 @@
 
 #
 # Dell OpenManage Ansible Modules
-# Version 7.0.0
-# Copyright (C) 2018-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Version 8.1.0
+# Copyright (C) 2018-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
@@ -31,7 +31,7 @@ options:
     description:
       - Select C(present) to create or modify a user account.
       - Select C(absent) to remove a user account.
-      - Ensure Lifecycle Controller is available because the user operation
+      - Ensure Lifecycle Controller is available because the user operation
         uses the capabilities of Lifecycle Controller.
     choices: [present, absent]
     default: present
@@ -59,7 +59,13 @@ options:
         access virtual console, access virtual media, and execute debug commands.
       - A user with C(ReadOnly) privilege can only log in to iDRAC.
       - A user with C(None), no privileges assigned.
+      - Will be ignored, if custom_privilege parameter is provided.
     choices: [Administrator, ReadOnly, Operator, None]
+  custom_privilege:
+    type: int
+    description:
+      - The privilege level assigned to the user.
+    version_added: "8.1.0"
   ipmi_lan_privilege:
     type: str
     description: The Intelligent Platform Management Interface LAN privilege level assigned to the user.
@@ -211,7 +217,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 ACCOUNT_URI = "/redfish/v1/Managers/iDRAC.Embedded.1/Accounts/"
 ATTRIBUTE_URI = "/redfish/v1/Managers/iDRAC.Embedded.1/Attributes/"
-PRIVILEGE = {"Administrator": 511, "Operator": 499, "ReadOnly": 1, "None": 0}
+USER_ROLES = {"Administrator": 511, "Operator": 499, "ReadOnly": 1, "None": 0}
 ACCESS = {0: "Disabled", 1: "Enabled"}
 
 
@@ -270,10 +276,13 @@ def get_payload(module, slot_id, action=None):
     :param slot_id: slot id for user slot
     :return: json data with slot id
     """
+    user_privilege = module.params["custom_privilege"] if "custom_privilege" in module.params and \
+        module.params["custom_privilege"] is not None else USER_ROLES.get(module.params["privilege"])
+
     slot_payload = {"Users.{0}.UserName": module.params["user_name"],
                     "Users.{0}.Password": module.params["user_password"],
                     "Users.{0}.Enable": ACCESS.get(module.params["enable"]),
-                    "Users.{0}.Privilege": PRIVILEGE.get(module.params["privilege"]),
+                    "Users.{0}.Privilege": user_privilege,
                     "Users.{0}.IpmiLanPrivilege": module.params["ipmi_lan_privilege"],
                     "Users.{0}.IpmiSerialPrivilege": module.params["ipmi_serial_privilege"],
                     "Users.{0}.SolEnable": ACCESS.get(module.params["sol_enable"]),
@@ -385,6 +394,7 @@ def main():
         "user_name": {"required": True},
         "user_password": {"required": False, "no_log": True},
         "privilege": {"required": False, "choices": ['Administrator', 'ReadOnly', 'Operator', 'None']},
+        "custom_privilege": {"required": False, "type": "int"},
         "ipmi_lan_privilege": {"required": False, "choices": ['Administrator', 'Operator', 'User', 'No Access']},
         "ipmi_serial_privilege": {"required": False, "choices": ['Administrator', 'Operator', 'User', 'No Access']},
         "enable": {"required": False, "type": "bool"},

--- a/tests/unit/plugins/modules/test_idrac_user.py
+++ b/tests/unit/plugins/modules/test_idrac_user.py
@@ -50,6 +50,17 @@ class TestIDRACUser(FakeAnsibleModule):
         resp = self.module.get_payload(f_module, 1, action="update")
         assert resp["Users.1.UserName"] == idrac_default_args["new_user_name"]
 
+    def test_get_payload_2(self, idrac_connection_user_mock, idrac_default_args, mocker):
+        idrac_default_args.update({"state": "present", "new_user_name": "new_user_name",
+                                   "user_name": "test", "user_password": "password",
+                                   "privilege": "Administrator", "custom_privilege": 17, "ipmi_lan_privilege": "Administrator",
+                                   "ipmi_serial_privilege": "Administrator", "enable": True,
+                                   "sol_enable": True, "protocol_enable": True,
+                                   "authentication_protocol": "SHA", "privacy_protocol": "AES"})
+        f_module = self.get_module_mock(params=idrac_default_args)
+        resp = self.module.get_payload(f_module, 1)
+        assert resp["Users.1.Privilege"] == idrac_default_args["custom_privilege"]
+
     def test_convert_payload_xml(self, idrac_connection_user_mock, idrac_default_args, mocker):
         idrac_default_args.update({"state": "present", "new_user_name": "new_user_name",
                                    "user_name": "test", "user_password": "password",


### PR DESCRIPTION
# Description
Created new parameter `custom_privileges` to be able to supply custom user privileges in the form of numeric codes.
If `privileges` and `custom_privileges` are given, `custom_privilges` prevail.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
idrac_user

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "authentication_protocol": "SHA",
            "ca_path": null,
            "custom_privilege": 17,
            "enable": true,
            "idrac_ip": "REDACTED",
            "idrac_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "idrac_port": 443,
            "idrac_user": "root",
            "ipmi_lan_privilege": "No Access",
            "ipmi_serial_privilege": null,
            "new_user_name": null,
            "privacy_protocol": "AES",
            "privilege": "Operator",
            "protocol_enable": true,
            "sol_enable": false,
            "state": "present",
            "timeout": 30,
            "user_name": "fence",
            "user_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "validate_certs": false
        }
    },
    "msg": "Successfully updated user account.",
    "status": {
        "@Message.ExtendedInfo": [
            {
                "Message": "The request completed successfully.",
                "MessageArgs": [],
                "MessageArgs@odata.count": 0,
                "MessageId": "Base.1.12.Success",
                "RelatedProperties": [],
                "RelatedProperties@odata.count": 0,
                "Resolution": "None",
                "Severity": "OK"
            },
            {
                "Message": "The operation successfully completed.",
                "MessageArgs": [],
                "MessageArgs@odata.count": 0,
                "MessageId": "IDRAC.2.8.SYS413",
                "RelatedProperties": [],
                "RelatedProperties@odata.count": 0,
                "Resolution": "No response action is required.",
                "Severity": "Informational"
            }
        ]
    }
}
```

![image](https://user-images.githubusercontent.com/57419021/229110440-57a0d83e-42d2-403a-8d78-e606bfd598c5.png)

```
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "authentication_protocol": "SHA",
            "ca_path": null,
            "custom_privilege": null,
            "enable": true,
            "idrac_ip": "REDACTED",
            "idrac_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "idrac_port": 443,
            "idrac_user": "root",
            "ipmi_lan_privilege": "No Access",
            "ipmi_serial_privilege": null,
            "new_user_name": null,
            "privacy_protocol": "AES",
            "privilege": "Operator",
            "protocol_enable": true,
            "sol_enable": false,
            "state": "present",
            "timeout": 30,
            "user_name": "fence",
            "user_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "validate_certs": false
        }
    },
    "msg": "Successfully updated user account.",
    "status": {
        "@Message.ExtendedInfo": [
            {
                "Message": "The request completed successfully.",
                "MessageArgs": [],
                "MessageArgs@odata.count": 0,
                "MessageId": "Base.1.12.Success",
                "RelatedProperties": [],
                "RelatedProperties@odata.count": 0,
                "Resolution": "None",
                "Severity": "OK"
            },
            {
                "Message": "The operation successfully completed.",
                "MessageArgs": [],
                "MessageArgs@odata.count": 0,
                "MessageId": "IDRAC.2.8.SYS413",
                "RelatedProperties": [],
                "RelatedProperties@odata.count": 0,
                "Resolution": "No response action is required.",
                "Severity": "Informational"
            }
        ]
    }
}
```

![image](https://user-images.githubusercontent.com/57419021/229111350-61005f6c-da09-4548-ba09-53ea73743eca.png)


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Introduced additional parameter `custom_privileges`. When the payload is generated and `custom_privileges` is set it will be taken for the payload. If it is not set, `priviliges` will be used in combination with the enum like before.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
# Checklist:

- [✔ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [❌ ] I have verified that new and existing unit tests pass locally with my changes
- [❔ ] I have not allowed coverage numbers to degenerate
- [ ❔] I have maintained at least 90% code coverage
- [✔ ] I have commented my code, particularly in hard-to-understand areas
- [✔ ] I have made corresponding changes to the documentation
- [ ✔] I have added tests that prove my fix is effective or that my feature works
- [ ✔] I have maintained backward compatibility