### PR TITLE
fix: wait until scp is applied (re-created PR)

### DIFF
--- a/plugins/module_utils/idrac_redfish.py
+++ b/plugins/module_utils/idrac_redfish.py
@@ -354,9 +354,6 @@ class iDRACRedfishAPI(object):
         if share.get("proxy_password") is not None:
             payload["ShareParameters"]["ProxyPassword"] = share["proxy_password"]
         response = self.invoke_request(IMPORT_URI, "POST", data=payload)
-        if response.status_code == 202 and job_wait:
-            task_uri = response.headers["Location"]
-            response = self.wait_for_job_complete(task_uri, job_wait=job_wait)
         return response
 
     def import_preview(self, import_buffer=None, target=None, share=None, job_wait=False):


### PR DESCRIPTION
# Description
Use idrac_redfish_job_tracking in `module_utils/utils.py` to track job progress so that ansible playbook completes after iDRAC SCP import job is actually completed when "job_wait: True".

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|#486 |

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
idrac_server_config_profile.py

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below
# ansible-playbook import_Config_SCP.yml -i inventory -e scp_config="firmware_scp.json" -vvv
ansible-playbook [core 2.14.1]
~~~~~

PLAYBOOK: import_Config_SCP.yml *******************************************************************
1 plays in import_Config_SCP.yml

PLAY [Server Configuration Profile] ***************************************************************

TASK [Import SCP from a network share and wait for this job to get completed] *********************
~~~~~

changed: [idracca] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "ca_path": null,
            "command": "import",
            "end_host_power_state": "On",
            "export_format": "XML",
            "export_use": "Default",
            "idrac_ip": "{iDRAC_IP_ADDRESS}",
            "idrac_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "idrac_port": 443,
            "idrac_user": "root",
            "ignore_certificate_warning": "ignore",
            "import_buffer": null,
            "include_in_export": "default",
            "job_wait": true,
            "proxy_password": null,
            "proxy_port": "80",
            "proxy_server": null,
            "proxy_support": false,
            "proxy_type": "http",
            "proxy_username": null,
            "scp_components": [
                "ALL"
            ],
            "scp_file": "firmware_scp.json",
            "share_name": "{NFS_ADDRESS}",
            "share_password": null,
            "share_user": null,
            "shutdown_type": "Graceful",
            "timeout": 30,
            "validate_certs": false
        }
    },
    "msg": "Successfully imported the Server Configuration Profile.",
    "scp_status": {
        "ActualRunningStartTime": "2023-04-12T16:33:20",
        "ActualRunningStopTime": "2023-04-12T16:42:49",
        "CompletionTime": "2023-04-12T16:42:49",
        "Id": "JID_812848002970",
        "JobState": "Completed",
        "JobType": "ImportConfiguration",
        "Message": "Successfully imported and applied Server Configuration Profile.",
        "MessageArgs": [],
        "MessageId": "SYS053",
        "PercentComplete": 100,
        "TargetSettingsURI": null,
        "file": "{NFS_ADDRESS}/firmware_scp.json",
        "retval": true
    }
}

PLAY RECAP ****************************************************************************************
idracca                    : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Tested on PowerEdge R650, iDRAC firmware version: 6.10.30.00
Please note that this was based on a fork from v7.4.0.
I checked diff on the below files which are related to my change, between v7.4.0 and my branch, and confirmed that there is no other possible changes.
```
plugins/module_utils/utils.py
plugins/module_utils/idrac_redfish.py 
plugins/modules/idrac_server_config_profile.py
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility