### PR TITLE
[Module][OMEM-Chassis Slots] changes for ansible 2.19 in omem chassis slots

### DIFF
--- a/docs/modules/ome_chassis_slots.rst
+++ b/docs/modules/ome_chassis_slots.rst
@@ -30,19 +30,19 @@ Parameters
   device_options (optional, list, None)
     The ID or service tag of the sled in the slot and the new name for the slot.
 
-    \ :emphasis:`device\_options`\  is mutually exclusive with \ :emphasis:`slot\_options`\ .
+    :emphasis:`device\_options` is mutually exclusive with :emphasis:`slot\_options`.
 
 
     device_id (optional, int, None)
       Device ID of the sled in the slot.
 
-      This is mutually exclusive with \ :emphasis:`device\_service\_tag`\ .
+      This is mutually exclusive with :emphasis:`device\_service\_tag`.
 
 
     device_service_tag (optional, str, None)
       Service tag of the sled in the slot.
 
-      This is mutually exclusive with \ :emphasis:`device\_id`\ .
+      This is mutually exclusive with :emphasis:`device\_id`.
 
 
     slot_name (True, str, None)
@@ -53,7 +53,7 @@ Parameters
   slot_options (optional, list, None)
     The service tag of the chassis, slot number of the slot to be renamed, and the new name for the slot.
 
-    \ :emphasis:`slot\_options`\  is mutually exclusive with \ :emphasis:`device\_options`\ .
+    :emphasis:`slot\_options` is mutually exclusive with :emphasis:`device\_options`.
 
 
     chassis_service_tag (True, str, None)
@@ -81,7 +81,7 @@ Parameters
   username (False, str, None)
     OpenManage Enterprise Modular username.
 
-    If the username is not provided, then the environment variable \ :envvar:`OME\_USERNAME`\  is used.
+    If the username is not provided, then the environment variable :envvar:`OME\_USERNAME` is used.
 
     Example: export OME\_USERNAME=username
 
@@ -89,7 +89,7 @@ Parameters
   password (False, str, None)
     OpenManage Enterprise Modular password.
 
-    If the password is not provided, then the environment variable \ :envvar:`OME\_PASSWORD`\  is used.
+    If the password is not provided, then the environment variable :envvar:`OME\_PASSWORD` is used.
 
     Example: export OME\_PASSWORD=password
 
@@ -97,7 +97,7 @@ Parameters
   x_auth_token (False, str, None)
     Authentication token.
 
-    If the x\_auth\_token is not provided, then the environment variable \ :envvar:`OME\_X\_AUTH\_TOKEN`\  is used.
+    If the x\_auth\_token is not provided, then the environment variable :envvar:`OME\_X\_AUTH\_TOKEN` is used.
 
     Example: export OME\_X\_AUTH\_TOKEN=x\_auth\_token
 
@@ -107,11 +107,11 @@ Parameters
 
 
   validate_certs (optional, bool, True)
-    If \ :literal:`false`\ , the SSL certificates will not be validated.
+    If :literal:`false`\ , the SSL certificates will not be validated.
 
-    Configure \ :literal:`false`\  only on personally controlled sites where self-signed certificates are used.
+    Configure :literal:`false` only on personally controlled sites where self-signed certificates are used.
 
-    Prior to collection version \ :literal:`5.0.0`\ , the \ :emphasis:`validate\_certs`\  is \ :literal:`false`\  by default.
+    Prior to collection version :literal:`5.0.0`\ , the :emphasis:`validate\_certs` is :literal:`false` by default.
 
 
   ca_path (optional, path, None)
@@ -131,7 +131,7 @@ Notes
 .. note::
    - This module initiates the refresh inventory task. It may take a minute for new names to be reflected. If the task exceeds 300 seconds to refresh, the task times out.
    - Run this module from a system that has direct access to Dell OpenManage Enterprise Modular.
-   - This module supports \ :literal:`check\_mode`\ .
+   - This module supports :literal:`check\_mode`.
 
 
 
@@ -211,17 +211,17 @@ msg (always, str, Successfully renamed the slot(s).)
 slot_info (if at least one slot renamed, list, [{'ChassisId': 10053, 'ChassisServiceTag': 'ABCD123', 'DeviceName': '', 'DeviceType': 1000, 'JobId': 15746, 'SlotId': '10072', 'SlotName': 'slot_op2', 'SlotNumber': '6', 'SlotType': 2000}, {'ChassisId': 10053, 'ChassisName': 'MX-ABCD123', 'ChassisServiceTag': 'ABCD123', 'DeviceType': '3000', 'JobId': 15747, 'SlotId': '10070', 'SlotName': 'slot_op2', 'SlotNumber': '4', 'SlotType': '2000'}, {'ChassisId': '10053', 'ChassisName': 'MX-PQRS123', 'ChassisServiceTag': 'PQRS123', 'DeviceId': '10054', 'DeviceServiceTag': 'XYZ5678', 'DeviceType': '1000', 'JobId': 15761, 'SlotId': '10067', 'SlotName': 'a1', 'SlotNumber': '1', 'SlotType': '2000'}])
   Information of the slots that are renamed successfully.
 
-  The \ :literal:`DeviceServiceTag`\  and \ :literal:`DeviceId`\  options are available only if \ :emphasis:`device\_options`\  is used.
+  The :literal:`DeviceServiceTag` and :literal:`DeviceId` options are available only if :emphasis:`device\_options` is used.
 
-  \ :literal:`NOTE`\  Only the slots which were renamed are listed.
+  :literal:`NOTE` Only the slots which were renamed are listed.
 
 
 rename_failed_slots (if at least one slot renaming fails, list, [{'ChassisId': '12345', 'ChassisName': 'MX-ABCD123', 'ChassisServiceTag': 'ABCD123', 'DeviceType': '4000', 'JobId': 1234, 'JobStatus': 'Aborted', 'SlotId': '10061', 'SlotName': 'c2', 'SlotNumber': '1', 'SlotType': '4000'}, {'ChassisId': '10053', 'ChassisName': 'MX-PQRS123', 'ChassisServiceTag': 'PQRS123', 'DeviceType': '1000', 'JobId': 0, 'JobStatus': 'HTTP Error 400: Bad Request', 'SlotId': '10069', 'SlotName': 'b2', 'SlotNumber': '3', 'SlotType': '2000'}])
   Information of the valid slots that are not renamed.
 
-  \ :literal:`JobStatus`\  is shown if rename job fails.
+  :literal:`JobStatus` is shown if rename job fails.
 
-  \ :literal:`NOTE`\  Only slots which were not renamed are listed.
+  :literal:`NOTE` Only slots which were not renamed are listed.
 
 
 error_info (on HTTP error, dict, {'error': {'code': 'Base.1.0.GeneralError', 'message': 'A general error has occurred. See ExtendedInfo for more information.', '@Message.ExtendedInfo': [{'MessageId': 'CGEN1014', 'RelatedProperties': [], 'Message': 'Unable to complete the operation because an invalid value is entered for the property Invalid json type: STRING for Edm.Int64 property: Id .', 'MessageArgs': ['Invalid json type: STRING for Edm.Int64 property: Id'], 'Severity': 'Critical', 'Resolution': "Enter a valid value for the property and retry the operation. For more information about valid values, see the OpenManage Enterprise-Modular User's Guide available on the support site."}]}})
@@ -242,4 +242,5 @@ Authors
 ~~~~~~~
 
 - Jagadeesh N V(@jagadeeshnv)
+- Akash Shendge(@shenda1)
 

--- a/plugins/modules/ome_chassis_slots.py
+++ b/plugins/modules/ome_chassis_slots.py
@@ -3,7 +3,7 @@
 
 #
 # Dell OpenManage Ansible Modules
-# Version 9.3.0
+# Version 10.1.0
 # Copyright (C) 2021-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -21,6 +21,7 @@ service tag or using chassis service tag and slot number."
 version_added: "3.6.0"
 author:
   - Jagadeesh N V(@jagadeeshnv)
+  - Akash Shendge(@shenda1)
 extends_documentation_fragment:
   - dellemc.openmanage.omem_auth_options
 options:
@@ -297,7 +298,7 @@ def get_device_slot_config(module, rest_obj):
             dvc_list.append(st)
     duplicate = [x for i, x in enumerate(dvc_list) if i != dvc_list.index(x)]
     if duplicate:
-        module.fail_json(msg=DEVICE_REPEATED.format((';'.join(set(duplicate)))))
+        module.exit_json(msg=DEVICE_REPEATED.format((';'.join(set(duplicate)))), failed=True)
     resp = rest_obj.get_all_items_with_pagination(DEVICE_URI)
     devices = resp.get('value')
     all_dvcs = {}
@@ -331,11 +332,11 @@ def get_device_slot_config(module, rest_obj):
     idf_list = list(ident_map.values())
     duplicate = [x for i, x in enumerate(idf_list) if i != idf_list.index(x)]
     if duplicate:
-        module.fail_json(msg=DEVICE_REPEATED.format((';'.join(set(duplicate)))))
+        module.exit_json(msg=DEVICE_REPEATED.format((';'.join(set(duplicate)))), failed=True)
     invalid_slots.update(set(ids.keys()) - set(ident_map.keys()))
     invalid_slots.update(set(tags.keys()) - set(ident_map.keys()))
     if invalid_slots:
-        module.fail_json(msg=INVALID_SLOT_DEVICE.format(';'.join(invalid_slots)))
+        module.exit_json(msg=INVALID_SLOT_DEVICE.format(';'.join(invalid_slots)), failed=True)
     slot_dict_diff = {}
     id_diff = recursive_diff(ids, name_map)
     if id_diff and id_diff[0]:
@@ -461,8 +462,8 @@ def exit_slot_config(module, rest_obj, failed_jobs, invalid_jobs, slot_data):
         s = len(slot_data)
         slot_info = get_formatted_slotlist(slot_data)
         failed_jobs_list = get_formatted_slotlist(failed_jobs)
-        module.fail_json(msg=FAILED_MSG.format(f, s + f),
-                         slot_info=slot_info, rename_failed_slots=failed_jobs_list)
+        module.exit_json(msg=FAILED_MSG.format(f, s + f),
+                         slot_info=slot_info, rename_failed_slots=failed_jobs_list, failed=True)
     if slot_data:
         job_failed_list = []
         try:
@@ -518,9 +519,9 @@ def get_slot_data(module, rest_obj, ch_slots, chass_id):
     input_dict = dict([(str(slot['slot_number']), slot['slot_name']) for slot in inp_slots])
     invalid_slot_number = set(input_dict.keys()) - set(existing_dict.keys())
     if invalid_slot_number:
-        module.fail_json(msg=INVALID_SLOT_NUMBERS.format(';'.join(invalid_slot_number)))
+        module.exit_json(msg=INVALID_SLOT_NUMBERS.format(';'.join(invalid_slot_number)), failed=True)
     if len(input_dict) < len(inp_slots):
-        module.fail_json(msg=SLOT_NUM_DUP.format(chsvc_tag))
+        module.exit_json(msg=SLOT_NUM_DUP.format(chsvc_tag), failed=True)
     slot_dict_diff = {}
     slot_diff = recursive_diff(input_dict, existing_dict)
     if slot_diff and slot_diff[0]:
@@ -540,11 +541,11 @@ def slot_number_config(module, rest_obj):
     input_chassi_list = list(chx.get('chassis_service_tag') for chx in chslots)
     duplicate = [x for i, x in enumerate(input_chassi_list) if i != input_chassi_list.index(x)]
     if duplicate:
-        module.fail_json(msg=CHASSIS_REPEATED.format((';'.join(set(duplicate)))))
+        module.exit_json(msg=CHASSIS_REPEATED.format((';'.join(set(duplicate)))), failed=True)
     for chx in chslots:
         chsvc_tag = chx.get('chassis_service_tag')
         if chsvc_tag not in chassi_dict.keys():
-            module.fail_json(msg=CHASSIS_TAG_INVALID.format(chsvc_tag))
+            module.exit_json(msg=CHASSIS_TAG_INVALID.format(chsvc_tag), failed=True)
         slot_dict = get_slot_data(module, rest_obj, chx, chassi_dict[chsvc_tag])
         slot_data.update(slot_dict)
     if not slot_data:
@@ -596,14 +597,14 @@ def main():
             if slot_data:
                 failed_jobs = get_job_states(module, rest_obj, slot_data)
             else:
-                module.fail_json(msg=JOBS_TRIG_FAIL, rename_failed_slots=list(invalid_jobs.values()))
+                module.exit_json(msg=JOBS_TRIG_FAIL, rename_failed_slots=list(invalid_jobs.values()), failed=True)
             exit_slot_config(module, rest_obj, failed_jobs, invalid_jobs, slot_data)
     except HTTPError as err:
-        module.fail_json(msg=str(err), error_info=json.load(err))
+        module.exit_json(msg=str(err), error_info=json.load(err), failed=True)
     except URLError as err:
         module.exit_json(msg=str(err), unreachable=True)
     except (IOError, ValueError, SSLError, TypeError, ConnectionError, AttributeError, IndexError, KeyError, OSError) as err:
-        module.fail_json(msg=str(err))
+        module.exit_json(msg=str(err), failed=True)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/ome_chassis_slots.py
+++ b/plugins/modules/ome_chassis_slots.py
@@ -3,7 +3,7 @@
 
 #
 # Dell OpenManage Ansible Modules
-# Version 10.1.0
+# Version 10.0.1
 # Copyright (C) 2021-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -23,6 +23,8 @@ from ansible_collections.dellemc.openmanage.plugins.modules import ome_chassis_s
 from ansible_collections.dellemc.openmanage.tests.unit.plugins.modules.common import FakeAnsibleModule
 
 DEVICE_REPEATED = "Duplicate device entry found for devices with identifiers {0}."
+CHASSIS_REPEATED = "Duplicate chassis entry found for chassis with service tags {0}."
+CHASSIS_TAG_INVALID = "Provided chassis {0} is invalid."
 INVALID_SLOT_DEVICE = "Unable to rename one or more slots because either the specified device is invalid or slots " \
                       "cannot be configured. The devices for which the slots cannot be renamed are: {0}."
 JOBS_TRIG_FAIL = "Unable to initiate the slot name rename jobs."
@@ -85,7 +87,37 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                       {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
                        "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
                                              "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': DEVICE_REPEATED,
-        "success": True}, ])
+        "success": True},
+        {
+        'mparams': {"device_options": []},
+        "invalid_list": set(["ABCD1234"]), "json_data": {
+            "value": [{"Id": 10053, "Identifier": "2H5DNX2", "SlotConfiguration": {"ChassisName": None}},
+                      {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234",
+                       "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
+                                             "SlotName": "my_840c", "SlotType": "2000"}},
+                      {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
+                       "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
+                                             "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': NO_CHANGES_MSG,
+        "success": True},
+        {
+         'mparams': {"device_options": [
+                                       {"slot_name": "s2",
+                                        "device_service_tag": "PQRS1234"}, ]},
+        "invalid_list": set(["PQRS1234"]), "json_data": {
+            "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
+                      {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
+                      {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]}, 'message': INVALID_SLOT_DEVICE,
+        "success": True},
+        {
+         'mparams': {"device_options": [
+                                       {"slot_name": "s2",
+                                        "device_id": 10054}, ]},
+        "invalid_list": set(["10054"]), "json_data": {
+            "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
+                      {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
+                      {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]}, 'message': INVALID_SLOT_DEVICE,
+        "success": True},
+        ])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock,
                                            ome_default_args, module_mock):
         ome_response_mock.success = params.get("success", True)
@@ -295,3 +327,66 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             result = self._run_module(ome_default_args)
             assert result['failed'] is True
         assert 'msg' in result
+
+    @pytest.mark.parametrize("params", [
+        {'mparams': {"slot_options": [
+                                        {
+                                            "chassis_service_tag": "ABC1234",
+                                            "slots": [
+                                                {"slot_name": "t1", "slot_number": 1},
+                                                {"slot_name": "s1", "slot_number": 5}
+                                            ]
+                                        },
+                                        {
+                                            "chassis_service_tag": "ABC1234",
+                                            "slots": [
+                                                {"slot_name": "t2", "slot_number": 2},
+                                                {"slot_name": "s2", "slot_number": 6}
+                                            ]
+                                        },
+                                    ]
+                                },
+         "invalid_list": set(["ABC1234"]),
+         "json_data":
+         {"value": [{"Id": 10053, "Identifier": "2H5DNX2",
+                     "SlotConfiguration": {"ChassisName": None}},
+                    {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
+                     "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
+                                           "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': CHASSIS_REPEATED,
+         "success": True},
+         {'mparams': {"slot_options": [
+                                        {
+                                            "chassis_service_tag": "ABC1234",
+                                            "slots": [
+                                                {"slot_name": "t1", "slot_number": 1},
+                                                {"slot_name": "s1", "slot_number": 5}
+                                            ]
+                                        },
+                                        {
+                                            "chassis_service_tag": "ABC1235",
+                                            "slots": [
+                                                {"slot_name": "t2", "slot_number": 2},
+                                                {"slot_name": "s2", "slot_number": 6}
+                                            ]
+                                        },
+                                    ]
+                                },
+         "invalid_list": set(["ABC1234"]),
+         "json_data":
+         {"value": [{"Id": 10053, "Identifier": "2H5DNX2",
+                     "SlotConfiguration": {"ChassisName": None}},
+                    {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
+                     "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
+                                           "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': CHASSIS_TAG_INVALID,
+         "success": True},
+         ])
+    def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock,
+                                        ome_default_args, module_mock):
+        ome_response_mock.success = params.get("success", True)
+        ome_response_mock.json_data = params['json_data']
+        ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params[
+            'json_data']
+        ome_default_args.update(params['mparams'])
+        result = self._run_module(ome_default_args)
+        assert result['msg'] == params['message'].format(
+            ';'.join(set(params.get("invalid_list"))))

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -115,10 +115,9 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                                       "slots": [{"slot_name": "t2", "slot_number": 2}, {"slot_name": "s2", "slot_number": 6}]}]},
         "invalid_list": {"ABC1234"},
         "json_data": {
-            "value": [
-                    {"Id": 10053, "Identifier": "2H5DNX2", "SlotConfiguration": {"ChassisName": None}},
-                    {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
-                     "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1", "SlotName": "my_840c", "SlotType": "2000"}}]},
+            "value": [{"Id": 10053, "Identifier": "2H5DNX2", "SlotConfiguration": {"ChassisName": None}},
+                      {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
+                       "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1", "SlotName": "my_840c", "SlotType": "2000"}}]},
         "message": CHASSIS_REPEATED,
         "success": True},
         {
@@ -162,8 +161,7 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             ]
         },
         "message": CHASSIS_TAG_INVALID,
-        "success": True,
-        }
+        "success": True}
     ])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
         # Test device slot config error

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -51,6 +51,12 @@ def ome_connection_mock_for_chassis_slots(mocker, ome_response_mock):
 
 class TestOmeChassisSlots(FakeAnsibleModule):
     module = ome_chassis_slots
+    def _run_config_error_test(self, params, ome_response_mock, ome_connection_mock, ome_default_args):
+        ome_response_mock.success = params.get("success", True)
+        ome_response_mock.json_data = params["json_data"]
+        ome_connection_mock.get_all_items_with_pagination.return_value = params["json_data"]
+        ome_default_args.update(params["mparams"])
+        return self._run_module(ome_default_args)
 
     @pytest.mark.parametrize("params", [{'mparams': {"device_options": [
         {"slot_name": "t1",
@@ -113,16 +119,10 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                       {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
                       {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]}, 'message': INVALID_SLOT_DEVICE,
         "success": True}])
-    def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock,
-                                           ome_default_args, module_mock):
-        ome_response_mock.success = params.get("success", True)
-        ome_response_mock.json_data = params['json_data']
-        ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params[
-            'json_data']
-        ome_default_args.update(params['mparams'])
-        result = self._run_module(ome_default_args)
-        assert result['msg'] == params['message'].format(
-            ';'.join(set(params.get("invalid_list"))))
+    def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
+        result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)
+        expected_msg = params["message"].format(';'.join(set(params.get("invalid_list"))))
+        assert result["msg"] == expected_msg
 
     @pytest.mark.parametrize("params", [{"json_data": {'Name': 'j1', 'Id': 24}, "slot_data": {
         "ABC1234": {"ChassisId": "123", "SlotNumber": "1", "SlotType": "2000"}}, "failed_jobs": {}}])
@@ -416,16 +416,10 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             },
         ]
     )
-    def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock,
-                                    ome_default_args, module_mock):
-        ome_response_mock.success = params.get("success", True)
-        ome_response_mock.json_data = params['json_data']
-        ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params[
-            'json_data']
-        ome_default_args.update(params['mparams'])
-        result = self._run_module(ome_default_args)
-        assert result['msg'] == params['message'].format(
-            ';'.join(set(params.get("invalid_list"))))
+    def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
+        result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)
+        expected_msg = params["message"].format(';'.join(set(params.get("invalid_list"))))
+        assert result["msg"] == expected_msg
 
     @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
                                                           "slots": [{"slot_name": "t1", "slot_number": 1},

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -104,17 +104,13 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
                       {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
                       {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]}, 'message': INVALID_SLOT_DEVICE,
-        "success": True},
-        {
-         'mparams': {"device_options": [
-                                       {"slot_name": "s2",
-                                        "device_id": 10054}, ]},
+        "success": True},{
+        'mparams': {"device_options": [{"slot_name": "s2","device_id": 10054}]},
         "invalid_list": set(["10054"]), "json_data": {
             "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
                       {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
                       {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]}, 'message': INVALID_SLOT_DEVICE,
-        "success": True},
-        ])
+        "success": True}])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock,
                                            ome_default_args, module_mock):
         ome_response_mock.success = params.get("success", True)
@@ -351,7 +347,7 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                      "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
                                            "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': CHASSIS_REPEATED,
          "success": True},
-         {'mparams': {"slot_options": [
+        {'mparams': {"slot_options": [
                                         {
                                             "chassis_service_tag": "ABC1234",
                                             "slots": [
@@ -367,18 +363,17 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                                             ]
                                         },
                                     ]
-                                },
-         "invalid_list": set(["ABC1234"]),
-         "json_data":
-         {"value": [{"Id": 10053, "Identifier": "2H5DNX2",
+                    },
+        "invalid_list": set(["ABC1234"]),
+        "json_data":
+        {"value": [{"Id": 10053, "Identifier": "2H5DNX2",
                      "SlotConfiguration": {"ChassisName": None}},
                     {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
                      "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
                                            "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': CHASSIS_TAG_INVALID,
-         "success": True},
-         ])
+        "success": True}])
     def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock,
-                                        ome_default_args, module_mock):
+                                    ome_default_args, module_mock):
         ome_response_mock.success = params.get("success", True)
         ome_response_mock.json_data = params['json_data']
         ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params[

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -2,7 +2,7 @@
 
 #
 # Dell OpenManage Ansible Modules
-# Version 10.1.0
+# Version 10.0.1
 # Copyright (C) 2021-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -463,37 +463,76 @@ class TestOmeChassisSlots(FakeAnsibleModule):
         expected_msg = INVALID_SLOT_NUMBERS.format(';'.join(params['invalid_list']))
         assert str(exc_info.value) == expected_msg
 
-    @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
-                                                        "slots": [{"slot_name": "t1", "slot_number": 1},
-                                                                {"slot_name": "s1", "slot_number": 5},
-                                                                {"slot_name": "s1", "slot_number": 5}]},
-                                        "chass_id": 1234, "chassi": {'value': [{"Identifier": "ABC1234", "Id": 1234}]},
-                                        "bladeslots": {'value': [{"SlotNumber": "1", "SlotName": "blade-slot1",
-                                                                "Id": 234}]},
-                                        "invalid_list": "ABC1234",
-                                        "storageslots": {'value': [{"ChassisServiceTag": "ABC1234",
-                                                                    "SlotConfiguration": {
-                                                                        "SlotId": "123", "SlotNumber": "5",
-                                                                        "SlotName": "stor-slot1"}}]},
-                                        "slot_dict_diff": {'ABC1234_5': {'SlotNumber': '5', 'SlotName': 'stor-slot1',
-                                                                        'ChassisId': 1234, 'SlotId': "123",
-                                                                        'ChassisServiceTag': 'ABC1234',
-                                                                        'new_name': 's1'},
-                                                        'ABC1234_1': {'SlotNumber': '1', 'SlotName': 'blade-slot1',
-                                                                        'ChassisId': 1234, 'SlotId': "234",
-                                                                        "Id": 234,
-                                                                        'ChassisServiceTag': 'ABC1234',
-                                                                        'new_name': 't1'}}}])
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {
+                "slot_options": {
+                    "chassis_service_tag": "ABC1234",
+                    "slots": [
+                        {"slot_name": "t1", "slot_number": 1},
+                        {"slot_name": "s1", "slot_number": 5},
+                        {"slot_name": "s1", "slot_number": 5},
+                    ],
+                },
+                "chass_id": 1234,
+                "chassi": {
+                    "value": [{"Identifier": "ABC1234", "Id": 1234}]
+                },
+                "bladeslots": {
+                    "value": [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]
+                },
+                "invalid_list": "ABC1234",
+                "storageslots": {
+                    "value": [
+                        {
+                            "ChassisServiceTag": "ABC1234",
+                            "SlotConfiguration": {
+                                "SlotId": "123",
+                                "SlotNumber": "5",
+                                "SlotName": "stor-slot1",
+                            },
+                        }
+                    ]
+                },
+                "slot_dict_diff": {
+                    "ABC1234_5": {
+                        "SlotNumber": "5",
+                        "SlotName": "stor-slot1",
+                        "ChassisId": 1234,
+                        "SlotId": "123",
+                        "ChassisServiceTag": "ABC1234",
+                        "new_name": "s1",
+                    },
+                    "ABC1234_1": {
+                        "SlotNumber": "1",
+                        "SlotName": "blade-slot1",
+                        "ChassisId": 1234,
+                        "SlotId": "234",
+                        "Id": 234,
+                        "ChassisServiceTag": "ABC1234",
+                        "new_name": "t1",
+                    },
+                },
+            }
+        ]
+    )
     def test_duplicate_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
         mocker.patch(
             MODULE_PATH + 'get_device_type',
-            return_value=params.get('storageslots'))
+            return_value=params.get('storageslots')
+        )
         ome_response_mock.json_data = params["bladeslots"]
         ch_slots = params['slot_options']
         f_module = self.get_module_mock()
-        with pytest.raises(AnsibleFailJSonException) as exc_info:
-            self.module.get_slot_data(f_module, ome_connection_mock_for_chassis_slots, ch_slots, params['chass_id'])
 
-        # Validate the error message
+        with pytest.raises(AnsibleFailJSonException) as exc_info:
+            self.module.get_slot_data(
+                f_module,
+                ome_connection_mock_for_chassis_slots,
+                ch_slots,
+                params['chass_id']
+            )
+
         expected_msg = SLOT_NUM_DUP.format(params['invalid_list'])
         assert str(exc_info.value) == expected_msg

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -107,7 +107,8 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                       {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
                        "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
                                              "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': NO_CHANGES_MSG,
-        "success": True}, {
+        "success": True},
+    {
         "mparams": {
             "slot_options": [
                 {
@@ -150,8 +151,8 @@ class TestOmeChassisSlots(FakeAnsibleModule):
         },
         "message": CHASSIS_REPEATED,
         "success": True,
-        },
-        {
+    },
+    {
         "mparams": {
             "slot_options": [
                 {
@@ -194,7 +195,7 @@ class TestOmeChassisSlots(FakeAnsibleModule):
         },
         "message": CHASSIS_TAG_INVALID,
         "success": True,
-        }])
+    }])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
         # Test device slot config error
         result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -430,23 +430,14 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                                                                     {"slot_name": "s1", "slot_number": 5},
                                                                     {"slot_name": "s2", "slot_number": 6}]},
                                          "chass_id": 1234, "chassi": {'value': [{"Identifier": "ABC1234", "Id": 1234}]},
-                                         "bladeslots": {'value': [{"SlotNumber": "1", "SlotName": "blade-slot1",
-                                                                   "Id": 234}]},
+                                         "bladeslots": {'value': [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
                                          "invalid_list": {"6"},
                                          "message": INVALID_SLOT_NUMBERS,
                                          "storageslots": {'value': [{"ChassisServiceTag": "ABC1234",
                                                                      "SlotConfiguration": {
                                                                          "SlotId": "123", "SlotNumber": "5",
                                                                          "SlotName": "stor-slot1"}}]},
-                                         "slot_dict_diff": {'ABC1234_5': {'SlotNumber': '5', 'SlotName': 'stor-slot1',
-                                                                          'ChassisId': 1234, 'SlotId': "123",
-                                                                          'ChassisServiceTag': 'ABC1234',
-                                                                          'new_name': 's1'},
-                                                            'ABC1234_1': {'SlotNumber': '1', 'SlotName': 'blade-slot1',
-                                                                          'ChassisId': 1234, 'SlotId': "234",
-                                                                          "Id": 234,
-                                                                          'ChassisServiceTag': 'ABC1234',
-                                                                          'new_name': 't1'}}}])
+                                         }])
     def test_invalid_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
         mocker.patch(
             MODULE_PATH + 'get_device_type',
@@ -474,12 +465,8 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                     ],
                 },
                 "chass_id": 1234,
-                "chassi": {
-                    "value": [{"Identifier": "ABC1234", "Id": 1234}]
-                },
-                "bladeslots": {
-                    "value": [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]
-                },
+                "chassi": {"value": [{"Identifier": "ABC1234", "Id": 1234}]},
+                "bladeslots": {"value": [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
                 "invalid_list": "ABC1234",
                 "storageslots": {
                     "value": [

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -493,25 +493,6 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                         }
                     ]
                 },
-                "slot_dict_diff": {
-                    "ABC1234_5": {
-                        "SlotNumber": "5",
-                        "SlotName": "stor-slot1",
-                        "ChassisId": 1234,
-                        "SlotId": "123",
-                        "ChassisServiceTag": "ABC1234",
-                        "new_name": "s1",
-                    },
-                    "ABC1234_1": {
-                        "SlotNumber": "1",
-                        "SlotName": "blade-slot1",
-                        "ChassisId": 1234,
-                        "SlotId": "234",
-                        "Id": 234,
-                        "ChassisServiceTag": "ABC1234",
-                        "new_name": "t1",
-                    },
-                },
             }
         ]
     )

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -161,7 +161,25 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             ]
         },
         "message": CHASSIS_TAG_INVALID,
-        "success": True}
+        "success": True},
+        {
+        'mparams': {"device_options": [{"slot_name": "s2", "device_service_tag": "PQRS1234"}]},
+        "invalid_list": set(["PQRS1234"]),
+        "json_data": {
+            "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
+                      {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
+                      {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]},
+        'message': INVALID_SLOT_DEVICE,
+        "success": True},
+        {
+        'mparams': {"device_options": [{"slot_name": "s2", "device_id": 10054}]},
+        "invalid_list": set(["10054"]),
+        "json_data": {
+            "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
+                      {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
+                      {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]},
+        'message': INVALID_SLOT_DEVICE,
+        "success": True},
     ])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
         # Test device slot config error

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -108,18 +108,6 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                        "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
                                              "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': NO_CHANGES_MSG,
         "success": True}, {
-        'mparams': {"device_options": [{"slot_name": "s2", "device_service_tag": "PQRS1234"}]},
-        "invalid_list": set(["PQRS1234"]), "json_data": {
-            "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
-                      {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
-                      {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]}, 'message': INVALID_SLOT_DEVICE,
-        "success": True}, {
-        'mparams': {"device_options": [{"slot_name": "s2", "device_id": 10054}]},
-        "invalid_list": set(["10054"]), "json_data": {
-            "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
-                      {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
-                      {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]}, 'message': INVALID_SLOT_DEVICE,
-        "success": True},{
                 "mparams": {
                     "slot_options": [
                         {

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -98,11 +98,8 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                       {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
                        "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
                                              "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': NO_CHANGES_MSG,
-        "success": True},
-        {
-         'mparams': {"device_options": [
-                                       {"slot_name": "s2",
-                                        "device_service_tag": "PQRS1234"}, ]},
+        "success": True}, {
+        'mparams': {"device_options": [{"slot_name": "s2", "device_service_tag": "PQRS1234"}]},
         "invalid_list": set(["PQRS1234"]), "json_data": {
             "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
                       {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -51,6 +51,7 @@ def ome_connection_mock_for_chassis_slots(mocker, ome_response_mock):
 
 class TestOmeChassisSlots(FakeAnsibleModule):
     module = ome_chassis_slots
+
     def _run_config_error_test(self, params, ome_response_mock, ome_connection_mock, ome_default_args):
         ome_response_mock.success = params.get("success", True)
         ome_response_mock.json_data = params["json_data"]
@@ -204,7 +205,6 @@ class TestOmeChassisSlots(FakeAnsibleModule):
     def test_ome_chassis_slots_success_case(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock,
                                             ome_default_args, mocker):
         ome_response_mock.success = params.get("success", True)
-        # ome_response_mock.json_data = params['json_data']
         ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params[
             'json_data']
         ome_connection_mock_for_chassis_slots.job_tracking.return_value = (

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -119,7 +119,94 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
                       {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
                       {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]}, 'message': INVALID_SLOT_DEVICE,
-        "success": True}])
+        "success": True},{
+                "mparams": {
+                    "slot_options": [
+                        {
+                            "chassis_service_tag": "ABC1234",
+                            "slots": [
+                                {"slot_name": "t1", "slot_number": 1},
+                                {"slot_name": "s1", "slot_number": 5},
+                            ],
+                        },
+                        {
+                            "chassis_service_tag": "ABC1234",
+                            "slots": [
+                                {"slot_name": "t2", "slot_number": 2},
+                                {"slot_name": "s2", "slot_number": 6},
+                            ],
+                        },
+                    ]
+                },
+                "invalid_list": {"ABC1234"},
+                "json_data": {
+                    "value": [
+                        {
+                            "Id": 10053,
+                            "Identifier": "2H5DNX2",
+                            "SlotConfiguration": {"ChassisName": None},
+                        },
+                        {
+                            "Id": 10054,
+                            "Type": 1000,
+                            "Identifier": "ABCD1234",
+                            "SlotConfiguration": {
+                                "DeviceType": "1000",
+                                "ChassisId": "10053",
+                                "SlotNumber": "1",
+                                "SlotName": "my_840c",
+                                "SlotType": "2000",
+                            },
+                        },
+                    ]
+                },
+                "message": CHASSIS_REPEATED,
+                "success": True,
+            },
+            {
+                "mparams": {
+                    "slot_options": [
+                        {
+                            "chassis_service_tag": "ABC1234",
+                            "slots": [
+                                {"slot_name": "t1", "slot_number": 1},
+                                {"slot_name": "s1", "slot_number": 5},
+                            ],
+                        },
+                        {
+                            "chassis_service_tag": "ABC1235",
+                            "slots": [
+                                {"slot_name": "t2", "slot_number": 2},
+                                {"slot_name": "s2", "slot_number": 6},
+                            ],
+                        },
+                    ]
+                },
+                "invalid_list": {"ABC1234"},
+                "json_data": {
+                    "value": [
+                        {
+                            "Id": 10053,
+                            "Identifier": "2H5DNX2",
+                            "SlotConfiguration": {"ChassisName": None},
+                        },
+                        {
+                            "Id": 10054,
+                            "Type": 1000,
+                            "Identifier": "ABCD1234",
+                            "SlotConfiguration": {
+                                "DeviceType": "1000",
+                                "ChassisId": "10053",
+                                "SlotNumber": "1",
+                                "SlotName": "my_840c",
+                                "SlotType": "2000",
+                            },
+                        },
+                    ]
+                },
+                "message": CHASSIS_TAG_INVALID,
+                "success": True,
+            },])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
         # Test device slot config error
         result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)
@@ -323,104 +410,6 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             result = self._run_module(ome_default_args)
             assert result['failed'] is True
         assert 'msg' in result
-
-    # @pytest.mark.parametrize(
-    #     "params",
-    #     [
-    #         {
-    #             "mparams": {
-    #                 "slot_options": [
-    #                     {
-    #                         "chassis_service_tag": "ABC1234",
-    #                         "slots": [
-    #                             {"slot_name": "t1", "slot_number": 1},
-    #                             {"slot_name": "s1", "slot_number": 5},
-    #                         ],
-    #                     },
-    #                     {
-    #                         "chassis_service_tag": "ABC1234",
-    #                         "slots": [
-    #                             {"slot_name": "t2", "slot_number": 2},
-    #                             {"slot_name": "s2", "slot_number": 6},
-    #                         ],
-    #                     },
-    #                 ]
-    #             },
-    #             "invalid_list": {"ABC1234"},
-    #             "json_data": {
-    #                 "value": [
-    #                     {
-    #                         "Id": 10053,
-    #                         "Identifier": "2H5DNX2",
-    #                         "SlotConfiguration": {"ChassisName": None},
-    #                     },
-    #                     {
-    #                         "Id": 10054,
-    #                         "Type": 1000,
-    #                         "Identifier": "ABCD1234",
-    #                         "SlotConfiguration": {
-    #                             "DeviceType": "1000",
-    #                             "ChassisId": "10053",
-    #                             "SlotNumber": "1",
-    #                             "SlotName": "my_840c",
-    #                             "SlotType": "2000",
-    #                         },
-    #                     },
-    #                 ]
-    #             },
-    #             "message": CHASSIS_REPEATED,
-    #             "success": True,
-    #         },
-    #         {
-    #             "mparams": {
-    #                 "slot_options": [
-    #                     {
-    #                         "chassis_service_tag": "ABC1234",
-    #                         "slots": [
-    #                             {"slot_name": "t1", "slot_number": 1},
-    #                             {"slot_name": "s1", "slot_number": 5},
-    #                         ],
-    #                     },
-    #                     {
-    #                         "chassis_service_tag": "ABC1235",
-    #                         "slots": [
-    #                             {"slot_name": "t2", "slot_number": 2},
-    #                             {"slot_name": "s2", "slot_number": 6},
-    #                         ],
-    #                     },
-    #                 ]
-    #             },
-    #             "invalid_list": {"ABC1234"},
-    #             "json_data": {
-    #                 "value": [
-    #                     {
-    #                         "Id": 10053,
-    #                         "Identifier": "2H5DNX2",
-    #                         "SlotConfiguration": {"ChassisName": None},
-    #                     },
-    #                     {
-    #                         "Id": 10054,
-    #                         "Type": 1000,
-    #                         "Identifier": "ABCD1234",
-    #                         "SlotConfiguration": {
-    #                             "DeviceType": "1000",
-    #                             "ChassisId": "10053",
-    #                             "SlotNumber": "1",
-    #                             "SlotName": "my_840c",
-    #                             "SlotType": "2000",
-    #                         },
-    #                     },
-    #                 ]
-    #             },
-    #             "message": CHASSIS_TAG_INVALID,
-    #             "success": True,
-    #         },
-    #     ]
-    # )
-    # # def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
-    #     result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)
-    #     expected_msg = params["message"].format(';'.join(set(params.get("invalid_list"))))
-    #     assert result["msg"] == expected_msg
 
     @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
                                                           "slots": [{"slot_name": "t1", "slot_number": 1},

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -324,103 +324,103 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             assert result['failed'] is True
         assert 'msg' in result
 
-    @pytest.mark.parametrize(
-        "params",
-        [
-            {
-                "mparams": {
-                    "slot_options": [
-                        {
-                            "chassis_service_tag": "ABC1234",
-                            "slots": [
-                                {"slot_name": "t1", "slot_number": 1},
-                                {"slot_name": "s1", "slot_number": 5},
-                            ],
-                        },
-                        {
-                            "chassis_service_tag": "ABC1234",
-                            "slots": [
-                                {"slot_name": "t2", "slot_number": 2},
-                                {"slot_name": "s2", "slot_number": 6},
-                            ],
-                        },
-                    ]
-                },
-                "invalid_list": {"ABC1234"},
-                "json_data": {
-                    "value": [
-                        {
-                            "Id": 10053,
-                            "Identifier": "2H5DNX2",
-                            "SlotConfiguration": {"ChassisName": None},
-                        },
-                        {
-                            "Id": 10054,
-                            "Type": 1000,
-                            "Identifier": "ABCD1234",
-                            "SlotConfiguration": {
-                                "DeviceType": "1000",
-                                "ChassisId": "10053",
-                                "SlotNumber": "1",
-                                "SlotName": "my_840c",
-                                "SlotType": "2000",
-                            },
-                        },
-                    ]
-                },
-                "message": CHASSIS_REPEATED,
-                "success": True,
-            },
-            {
-                "mparams": {
-                    "slot_options": [
-                        {
-                            "chassis_service_tag": "ABC1234",
-                            "slots": [
-                                {"slot_name": "t1", "slot_number": 1},
-                                {"slot_name": "s1", "slot_number": 5},
-                            ],
-                        },
-                        {
-                            "chassis_service_tag": "ABC1235",
-                            "slots": [
-                                {"slot_name": "t2", "slot_number": 2},
-                                {"slot_name": "s2", "slot_number": 6},
-                            ],
-                        },
-                    ]
-                },
-                "invalid_list": {"ABC1234"},
-                "json_data": {
-                    "value": [
-                        {
-                            "Id": 10053,
-                            "Identifier": "2H5DNX2",
-                            "SlotConfiguration": {"ChassisName": None},
-                        },
-                        {
-                            "Id": 10054,
-                            "Type": 1000,
-                            "Identifier": "ABCD1234",
-                            "SlotConfiguration": {
-                                "DeviceType": "1000",
-                                "ChassisId": "10053",
-                                "SlotNumber": "1",
-                                "SlotName": "my_840c",
-                                "SlotType": "2000",
-                            },
-                        },
-                    ]
-                },
-                "message": CHASSIS_TAG_INVALID,
-                "success": True,
-            },
-        ]
-    )
-    def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
-        result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)
-        expected_msg = params["message"].format(';'.join(set(params.get("invalid_list"))))
-        assert result["msg"] == expected_msg
+    # @pytest.mark.parametrize(
+    #     "params",
+    #     [
+    #         {
+    #             "mparams": {
+    #                 "slot_options": [
+    #                     {
+    #                         "chassis_service_tag": "ABC1234",
+    #                         "slots": [
+    #                             {"slot_name": "t1", "slot_number": 1},
+    #                             {"slot_name": "s1", "slot_number": 5},
+    #                         ],
+    #                     },
+    #                     {
+    #                         "chassis_service_tag": "ABC1234",
+    #                         "slots": [
+    #                             {"slot_name": "t2", "slot_number": 2},
+    #                             {"slot_name": "s2", "slot_number": 6},
+    #                         ],
+    #                     },
+    #                 ]
+    #             },
+    #             "invalid_list": {"ABC1234"},
+    #             "json_data": {
+    #                 "value": [
+    #                     {
+    #                         "Id": 10053,
+    #                         "Identifier": "2H5DNX2",
+    #                         "SlotConfiguration": {"ChassisName": None},
+    #                     },
+    #                     {
+    #                         "Id": 10054,
+    #                         "Type": 1000,
+    #                         "Identifier": "ABCD1234",
+    #                         "SlotConfiguration": {
+    #                             "DeviceType": "1000",
+    #                             "ChassisId": "10053",
+    #                             "SlotNumber": "1",
+    #                             "SlotName": "my_840c",
+    #                             "SlotType": "2000",
+    #                         },
+    #                     },
+    #                 ]
+    #             },
+    #             "message": CHASSIS_REPEATED,
+    #             "success": True,
+    #         },
+    #         {
+    #             "mparams": {
+    #                 "slot_options": [
+    #                     {
+    #                         "chassis_service_tag": "ABC1234",
+    #                         "slots": [
+    #                             {"slot_name": "t1", "slot_number": 1},
+    #                             {"slot_name": "s1", "slot_number": 5},
+    #                         ],
+    #                     },
+    #                     {
+    #                         "chassis_service_tag": "ABC1235",
+    #                         "slots": [
+    #                             {"slot_name": "t2", "slot_number": 2},
+    #                             {"slot_name": "s2", "slot_number": 6},
+    #                         ],
+    #                     },
+    #                 ]
+    #             },
+    #             "invalid_list": {"ABC1234"},
+    #             "json_data": {
+    #                 "value": [
+    #                     {
+    #                         "Id": 10053,
+    #                         "Identifier": "2H5DNX2",
+    #                         "SlotConfiguration": {"ChassisName": None},
+    #                     },
+    #                     {
+    #                         "Id": 10054,
+    #                         "Type": 1000,
+    #                         "Identifier": "ABCD1234",
+    #                         "SlotConfiguration": {
+    #                             "DeviceType": "1000",
+    #                             "ChassisId": "10053",
+    #                             "SlotNumber": "1",
+    #                             "SlotName": "my_840c",
+    #                             "SlotType": "2000",
+    #                         },
+    #                     },
+    #                 ]
+    #             },
+    #             "message": CHASSIS_TAG_INVALID,
+    #             "success": True,
+    #         },
+    #     ]
+    # )
+    # # def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
+    #     result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)
+    #     expected_msg = params["message"].format(';'.join(set(params.get("invalid_list"))))
+    #     assert result["msg"] == expected_msg
 
     @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
                                                           "slots": [{"slot_name": "t1", "slot_number": 1},

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -121,6 +121,7 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                       {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]}, 'message': INVALID_SLOT_DEVICE,
         "success": True}])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
+        # Test device slot config error
         result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)
         expected_msg = params["message"].format(';'.join(set(params.get("invalid_list"))))
         assert result["msg"] == expected_msg
@@ -417,9 +418,12 @@ class TestOmeChassisSlots(FakeAnsibleModule):
         ]
     )
     def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
-        result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)
-        expected_msg = params["message"].format(';'.join(set(params.get("invalid_list"))))
-        assert result["msg"] == expected_msg
+        ome_response_mock.success = params.get("success", True)
+        ome_response_mock.json_data = params["json_data"]
+        ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params["json_data"]
+        ome_default_args.update(params["mparams"])
+        result = self._run_module(ome_default_args)
+        assert result["msg"] == params["message"].format(';'.join(set(params.get("invalid_list"))))
 
     @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
                                                           "slots": [{"slot_name": "t1", "slot_number": 1},

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -195,7 +195,8 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             },
             "message": CHASSIS_TAG_INVALID,
             "success": True,
-        }])
+        }
+    ])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
         # Test device slot config error
         result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -108,93 +108,93 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                        "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
                                              "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': NO_CHANGES_MSG,
         "success": True}, {
-                "mparams": {
-                    "slot_options": [
-                        {
-                            "chassis_service_tag": "ABC1234",
-                            "slots": [
-                                {"slot_name": "t1", "slot_number": 1},
-                                {"slot_name": "s1", "slot_number": 5},
-                            ],
-                        },
-                        {
-                            "chassis_service_tag": "ABC1234",
-                            "slots": [
-                                {"slot_name": "t2", "slot_number": 2},
-                                {"slot_name": "s2", "slot_number": 6},
-                            ],
-                        },
-                    ]
+        "mparams": {
+            "slot_options": [
+                {
+                    "chassis_service_tag": "ABC1234",
+                    "slots": [
+                        {"slot_name": "t1", "slot_number": 1},
+                        {"slot_name": "s1", "slot_number": 5},
+                    ],
                 },
-                "invalid_list": {"ABC1234"},
-                "json_data": {
-                    "value": [
-                        {
-                            "Id": 10053,
-                            "Identifier": "2H5DNX2",
-                            "SlotConfiguration": {"ChassisName": None},
-                        },
-                        {
-                            "Id": 10054,
-                            "Type": 1000,
-                            "Identifier": "ABCD1234",
-                            "SlotConfiguration": {
-                                "DeviceType": "1000",
-                                "ChassisId": "10053",
-                                "SlotNumber": "1",
-                                "SlotName": "my_840c",
-                                "SlotType": "2000",
-                            },
-                        },
-                    ]
+                {
+                    "chassis_service_tag": "ABC1234",
+                    "slots": [
+                        {"slot_name": "t2", "slot_number": 2},
+                        {"slot_name": "s2", "slot_number": 6},
+                    ],
                 },
-                "message": CHASSIS_REPEATED,
-                "success": True,
-            },
-            {
-                "mparams": {
-                    "slot_options": [
-                        {
-                            "chassis_service_tag": "ABC1234",
-                            "slots": [
-                                {"slot_name": "t1", "slot_number": 1},
-                                {"slot_name": "s1", "slot_number": 5},
-                            ],
-                        },
-                        {
-                            "chassis_service_tag": "ABC1235",
-                            "slots": [
-                                {"slot_name": "t2", "slot_number": 2},
-                                {"slot_name": "s2", "slot_number": 6},
-                            ],
-                        },
-                    ]
+            ]
+        },
+        "invalid_list": {"ABC1234"},
+        "json_data": {
+            "value": [
+                {
+                    "Id": 10053,
+                    "Identifier": "2H5DNX2",
+                    "SlotConfiguration": {"ChassisName": None},
                 },
-                "invalid_list": {"ABC1234"},
-                "json_data": {
-                    "value": [
-                        {
-                            "Id": 10053,
-                            "Identifier": "2H5DNX2",
-                            "SlotConfiguration": {"ChassisName": None},
-                        },
-                        {
-                            "Id": 10054,
-                            "Type": 1000,
-                            "Identifier": "ABCD1234",
-                            "SlotConfiguration": {
-                                "DeviceType": "1000",
-                                "ChassisId": "10053",
-                                "SlotNumber": "1",
-                                "SlotName": "my_840c",
-                                "SlotType": "2000",
-                            },
-                        },
-                    ]
+                {
+                    "Id": 10054,
+                    "Type": 1000,
+                    "Identifier": "ABCD1234",
+                    "SlotConfiguration": {
+                        "DeviceType": "1000",
+                        "ChassisId": "10053",
+                        "SlotNumber": "1",
+                        "SlotName": "my_840c",
+                        "SlotType": "2000",
+                    },
                 },
-                "message": CHASSIS_TAG_INVALID,
-                "success": True,
-            },])
+            ]
+        },
+        "message": CHASSIS_REPEATED,
+        "success": True,
+        },
+        {
+        "mparams": {
+            "slot_options": [
+                {
+                    "chassis_service_tag": "ABC1234",
+                    "slots": [
+                        {"slot_name": "t1", "slot_number": 1},
+                        {"slot_name": "s1", "slot_number": 5},
+                    ],
+                },
+                {
+                    "chassis_service_tag": "ABC1235",
+                    "slots": [
+                        {"slot_name": "t2", "slot_number": 2},
+                        {"slot_name": "s2", "slot_number": 6},
+                    ],
+                },
+            ]
+        },
+        "invalid_list": {"ABC1234"},
+        "json_data": {
+            "value": [
+                {
+                    "Id": 10053,
+                    "Identifier": "2H5DNX2",
+                    "SlotConfiguration": {"ChassisName": None},
+                },
+                {
+                    "Id": 10054,
+                    "Type": 1000,
+                    "Identifier": "ABCD1234",
+                    "SlotConfiguration": {
+                        "DeviceType": "1000",
+                        "ChassisId": "10053",
+                        "SlotNumber": "1",
+                        "SlotName": "my_840c",
+                        "SlotType": "2000",
+                    },
+                },
+            ]
+        },
+        "message": CHASSIS_TAG_INVALID,
+        "success": True,
+        }])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
         # Test device slot config error
         result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)
@@ -399,46 +399,73 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             assert result['failed'] is True
         assert 'msg' in result
 
-    @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
-                                                          "slots": [{"slot_name": "t1", "slot_number": 1},
-                                                                    {"slot_name": "s1", "slot_number": 5},
-                                                                    {"slot_name": "s2", "slot_number": 6}]},
-                                         "chass_id": 1234, "chassi": {'value': [{"Identifier": "ABC1234", "Id": 1234}]},
-                                         "bladeslots": {'value': [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
-                                         "invalid_list": {"6"},
-                                         "message": INVALID_SLOT_NUMBERS,
-                                         "storageslots": {'value': [{"ChassisServiceTag": "ABC1234",
-                                                                     "SlotConfiguration": {
-                                                                         "SlotId": "123", "SlotNumber": "5",
-                                                                         "SlotName": "stor-slot1"}}]},
-                                         },
-                                         {
-                                            "slot_options": {
-                                                "chassis_service_tag": "ABC1234",
-                                                "slots": [
-                                                    {"slot_name": "t1", "slot_number": 1},
-                                                    {"slot_name": "s1", "slot_number": 5},
-                                                    {"slot_name": "s1", "slot_number": 5},
-                                                ],
-                                            },
-                                            "chass_id": 1234,
-                                            "chassi": {"value": [{"Identifier": "ABC1234", "Id": 1234}]},
-                                            "bladeslots": {"value": [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
-                                            "invalid_list": {"ABC1234"},
-                                            "message": SLOT_NUM_DUP,
-                                            "storageslots": {
-                                                "value": [
-                                                    {
-                                                        "ChassisServiceTag": "ABC1234",
-                                                        "SlotConfiguration": {
-                                                            "SlotId": "123",
-                                                            "SlotNumber": "5",
-                                                            "SlotName": "stor-slot1",
-                                                        },
-                                                    }
-                                                ]
-                                            },
-                                         }])
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {
+                "slot_options": {
+                    "chassis_service_tag": "ABC1234",
+                    "slots": [
+                        {"slot_name": "t1", "slot_number": 1},
+                        {"slot_name": "s1", "slot_number": 5},
+                        {"slot_name": "s2", "slot_number": 6},
+                    ],
+                },
+                "chass_id": 1234,
+                "chassi": {
+                    "value": [{"Identifier": "ABC1234", "Id": 1234}]
+                },
+                "bladeslots": {
+                    "value": [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]
+                },
+                "invalid_list": {"6"},
+                "message": INVALID_SLOT_NUMBERS,
+                "storageslots": {
+                    "value": [
+                        {
+                            "ChassisServiceTag": "ABC1234",
+                            "SlotConfiguration": {
+                                "SlotId": "123",
+                                "SlotNumber": "5",
+                                "SlotName": "stor-slot1",
+                            },
+                        }
+                    ]
+                },
+            },
+            {
+                "slot_options": {
+                    "chassis_service_tag": "ABC1234",
+                    "slots": [
+                        {"slot_name": "t1", "slot_number": 1},
+                        {"slot_name": "s1", "slot_number": 5},
+                        {"slot_name": "s1", "slot_number": 5},
+                    ],
+                },
+                "chass_id": 1234,
+                "chassi": {
+                    "value": [{"Identifier": "ABC1234", "Id": 1234}]
+                },
+                "bladeslots": {
+                    "value": [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]
+                },
+                "invalid_list": {"ABC1234"},
+                "message": SLOT_NUM_DUP,
+                "storageslots": {
+                    "value": [
+                        {
+                            "ChassisServiceTag": "ABC1234",
+                            "SlotConfiguration": {
+                                "SlotId": "123",
+                                "SlotNumber": "5",
+                                "SlotName": "stor-slot1",
+                            },
+                        }
+                    ]
+                },
+            },
+        ]
+    )
     def test_invalid_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
         mocker.patch(
             MODULE_PATH + 'get_device_type',

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -418,12 +418,9 @@ class TestOmeChassisSlots(FakeAnsibleModule):
         ]
     )
     def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
-        ome_response_mock.success = params.get("success", True)
-        ome_response_mock.json_data = params["json_data"]
-        ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params["json_data"]
-        ome_default_args.update(params["mparams"])
-        result = self._run_module(ome_default_args)
-        assert result["msg"] == params["message"].format(';'.join(set(params.get("invalid_list"))))
+        result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)
+        expected_msg = params["message"].format(';'.join(set(params.get("invalid_list"))))
+        assert result["msg"] == expected_msg
 
     @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
                                                           "slots": [{"slot_name": "t1", "slot_number": 1},

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -324,181 +324,181 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             assert result['failed'] is True
         assert 'msg' in result
 
-    @pytest.mark.parametrize(
-        "params",
-        [
-            {
-                "mparams": {
-                    "slot_options": [
-                        {
-                            "chassis_service_tag": "ABC1234",
-                            "slots": [
-                                {"slot_name": "t1", "slot_number": 1},
-                                {"slot_name": "s1", "slot_number": 5},
-                            ],
-                        },
-                        {
-                            "chassis_service_tag": "ABC1234",
-                            "slots": [
-                                {"slot_name": "t2", "slot_number": 2},
-                                {"slot_name": "s2", "slot_number": 6},
-                            ],
-                        },
-                    ]
-                },
-                "invalid_list": {"ABC1234"},
-                "json_data": {
-                    "value": [
-                        {
-                            "Id": 10053,
-                            "Identifier": "2H5DNX2",
-                            "SlotConfiguration": {"ChassisName": None},
-                        },
-                        {
-                            "Id": 10054,
-                            "Type": 1000,
-                            "Identifier": "ABCD1234",
-                            "SlotConfiguration": {
-                                "DeviceType": "1000",
-                                "ChassisId": "10053",
-                                "SlotNumber": "1",
-                                "SlotName": "my_840c",
-                                "SlotType": "2000",
-                            },
-                        },
-                    ]
-                },
-                "message": CHASSIS_REPEATED,
-                "success": True,
-            },
-            {
-                "mparams": {
-                    "slot_options": [
-                        {
-                            "chassis_service_tag": "ABC1234",
-                            "slots": [
-                                {"slot_name": "t1", "slot_number": 1},
-                                {"slot_name": "s1", "slot_number": 5},
-                            ],
-                        },
-                        {
-                            "chassis_service_tag": "ABC1235",
-                            "slots": [
-                                {"slot_name": "t2", "slot_number": 2},
-                                {"slot_name": "s2", "slot_number": 6},
-                            ],
-                        },
-                    ]
-                },
-                "invalid_list": {"ABC1234"},
-                "json_data": {
-                    "value": [
-                        {
-                            "Id": 10053,
-                            "Identifier": "2H5DNX2",
-                            "SlotConfiguration": {"ChassisName": None},
-                        },
-                        {
-                            "Id": 10054,
-                            "Type": 1000,
-                            "Identifier": "ABCD1234",
-                            "SlotConfiguration": {
-                                "DeviceType": "1000",
-                                "ChassisId": "10053",
-                                "SlotNumber": "1",
-                                "SlotName": "my_840c",
-                                "SlotType": "2000",
-                            },
-                        },
-                    ]
-                },
-                "message": CHASSIS_TAG_INVALID,
-                "success": True,
-            },
-        ]
-    )
-    def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
-        ome_response_mock.success = params.get("success", True)
-        ome_response_mock.json_data = params["json_data"]
-        ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params["json_data"]
-        ome_default_args.update(params["mparams"])
-        result = self._run_module(ome_default_args)
-        assert result["msg"] == params["message"].format(';'.join(set(params.get("invalid_list"))))
+    # @pytest.mark.parametrize(
+    #     "params",
+    #     [
+    #         {
+    #             "mparams": {
+    #                 "slot_options": [
+    #                     {
+    #                         "chassis_service_tag": "ABC1234",
+    #                         "slots": [
+    #                             {"slot_name": "t1", "slot_number": 1},
+    #                             {"slot_name": "s1", "slot_number": 5},
+    #                         ],
+    #                     },
+    #                     {
+    #                         "chassis_service_tag": "ABC1234",
+    #                         "slots": [
+    #                             {"slot_name": "t2", "slot_number": 2},
+    #                             {"slot_name": "s2", "slot_number": 6},
+    #                         ],
+    #                     },
+    #                 ]
+    #             },
+    #             "invalid_list": {"ABC1234"},
+    #             "json_data": {
+    #                 "value": [
+    #                     {
+    #                         "Id": 10053,
+    #                         "Identifier": "2H5DNX2",
+    #                         "SlotConfiguration": {"ChassisName": None},
+    #                     },
+    #                     {
+    #                         "Id": 10054,
+    #                         "Type": 1000,
+    #                         "Identifier": "ABCD1234",
+    #                         "SlotConfiguration": {
+    #                             "DeviceType": "1000",
+    #                             "ChassisId": "10053",
+    #                             "SlotNumber": "1",
+    #                             "SlotName": "my_840c",
+    #                             "SlotType": "2000",
+    #                         },
+    #                     },
+    #                 ]
+    #             },
+    #             "message": CHASSIS_REPEATED,
+    #             "success": True,
+    #         },
+    #         {
+    #             "mparams": {
+    #                 "slot_options": [
+    #                     {
+    #                         "chassis_service_tag": "ABC1234",
+    #                         "slots": [
+    #                             {"slot_name": "t1", "slot_number": 1},
+    #                             {"slot_name": "s1", "slot_number": 5},
+    #                         ],
+    #                     },
+    #                     {
+    #                         "chassis_service_tag": "ABC1235",
+    #                         "slots": [
+    #                             {"slot_name": "t2", "slot_number": 2},
+    #                             {"slot_name": "s2", "slot_number": 6},
+    #                         ],
+    #                     },
+    #                 ]
+    #             },
+    #             "invalid_list": {"ABC1234"},
+    #             "json_data": {
+    #                 "value": [
+    #                     {
+    #                         "Id": 10053,
+    #                         "Identifier": "2H5DNX2",
+    #                         "SlotConfiguration": {"ChassisName": None},
+    #                     },
+    #                     {
+    #                         "Id": 10054,
+    #                         "Type": 1000,
+    #                         "Identifier": "ABCD1234",
+    #                         "SlotConfiguration": {
+    #                             "DeviceType": "1000",
+    #                             "ChassisId": "10053",
+    #                             "SlotNumber": "1",
+    #                             "SlotName": "my_840c",
+    #                             "SlotType": "2000",
+    #                         },
+    #                     },
+    #                 ]
+    #             },
+    #             "message": CHASSIS_TAG_INVALID,
+    #             "success": True,
+    #         },
+    #     ]
+    # )
+    # def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
+    #     ome_response_mock.success = params.get("success", True)
+    #     ome_response_mock.json_data = params["json_data"]
+    #     ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params["json_data"]
+    #     ome_default_args.update(params["mparams"])
+    #     result = self._run_module(ome_default_args)
+    #     assert result["msg"] == params["message"].format(';'.join(set(params.get("invalid_list"))))
 
-    @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
-                                                          "slots": [{"slot_name": "t1", "slot_number": 1},
-                                                                    {"slot_name": "s1", "slot_number": 5},
-                                                                    {"slot_name": "s2", "slot_number": 6}]},
-                                         "chass_id": 1234, "chassi": {'value': [{"Identifier": "ABC1234", "Id": 1234}]},
-                                         "bladeslots": {'value': [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
-                                         "invalid_list": {"6"},
-                                         "message": INVALID_SLOT_NUMBERS,
-                                         "storageslots": {'value': [{"ChassisServiceTag": "ABC1234",
-                                                                     "SlotConfiguration": {
-                                                                         "SlotId": "123", "SlotNumber": "5",
-                                                                         "SlotName": "stor-slot1"}}]},
-                                         }])
-    def test_invalid_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
-        mocker.patch(
-            MODULE_PATH + 'get_device_type',
-            return_value=params.get('storageslots'))
-        ome_response_mock.json_data = params["bladeslots"]
-        ch_slots = params['slot_options']
-        f_module = self.get_module_mock()
-        with pytest.raises(AnsibleFailJSonException) as exc_info:
-            self.module.get_slot_data(f_module, ome_connection_mock_for_chassis_slots, ch_slots, params['chass_id'])
+    # @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
+    #                                                       "slots": [{"slot_name": "t1", "slot_number": 1},
+    #                                                                 {"slot_name": "s1", "slot_number": 5},
+    #                                                                 {"slot_name": "s2", "slot_number": 6}]},
+    #                                      "chass_id": 1234, "chassi": {'value': [{"Identifier": "ABC1234", "Id": 1234}]},
+    #                                      "bladeslots": {'value': [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
+    #                                      "invalid_list": {"6"},
+    #                                      "message": INVALID_SLOT_NUMBERS,
+    #                                      "storageslots": {'value': [{"ChassisServiceTag": "ABC1234",
+    #                                                                  "SlotConfiguration": {
+    #                                                                      "SlotId": "123", "SlotNumber": "5",
+    #                                                                      "SlotName": "stor-slot1"}}]},
+    #                                      }])
+    # def test_invalid_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
+    #     mocker.patch(
+    #         MODULE_PATH + 'get_device_type',
+    #         return_value=params.get('storageslots'))
+    #     ome_response_mock.json_data = params["bladeslots"]
+    #     ch_slots = params['slot_options']
+    #     f_module = self.get_module_mock()
+    #     with pytest.raises(AnsibleFailJSonException) as exc_info:
+    #         self.module.get_slot_data(f_module, ome_connection_mock_for_chassis_slots, ch_slots, params['chass_id'])
 
-        # Validate the error message
-        expected_msg = INVALID_SLOT_NUMBERS.format(';'.join(params['invalid_list']))
-        assert str(exc_info.value) == expected_msg
+    #     # Validate the error message
+    #     expected_msg = INVALID_SLOT_NUMBERS.format(';'.join(params['invalid_list']))
+    #     assert str(exc_info.value) == expected_msg
 
-    @pytest.mark.parametrize(
-        "params",
-        [
-            {
-                "slot_options": {
-                    "chassis_service_tag": "ABC1234",
-                    "slots": [
-                        {"slot_name": "t1", "slot_number": 1},
-                        {"slot_name": "s1", "slot_number": 5},
-                        {"slot_name": "s1", "slot_number": 5},
-                    ],
-                },
-                "chass_id": 1234,
-                "chassi": {"value": [{"Identifier": "ABC1234", "Id": 1234}]},
-                "bladeslots": {"value": [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
-                "invalid_list": "ABC1234",
-                "storageslots": {
-                    "value": [
-                        {
-                            "ChassisServiceTag": "ABC1234",
-                            "SlotConfiguration": {
-                                "SlotId": "123",
-                                "SlotNumber": "5",
-                                "SlotName": "stor-slot1",
-                            },
-                        }
-                    ]
-                },
-            }
-        ]
-    )
-    def test_duplicate_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
-        mocker.patch(
-            MODULE_PATH + 'get_device_type',
-            return_value=params.get('storageslots')
-        )
-        ome_response_mock.json_data = params["bladeslots"]
-        ch_slots = params['slot_options']
-        f_module = self.get_module_mock()
+    # @pytest.mark.parametrize(
+    #     "params",
+    #     [
+    #         {
+    #             "slot_options": {
+    #                 "chassis_service_tag": "ABC1234",
+    #                 "slots": [
+    #                     {"slot_name": "t1", "slot_number": 1},
+    #                     {"slot_name": "s1", "slot_number": 5},
+    #                     {"slot_name": "s1", "slot_number": 5},
+    #                 ],
+    #             },
+    #             "chass_id": 1234,
+    #             "chassi": {"value": [{"Identifier": "ABC1234", "Id": 1234}]},
+    #             "bladeslots": {"value": [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
+    #             "invalid_list": "ABC1234",
+    #             "storageslots": {
+    #                 "value": [
+    #                     {
+    #                         "ChassisServiceTag": "ABC1234",
+    #                         "SlotConfiguration": {
+    #                             "SlotId": "123",
+    #                             "SlotNumber": "5",
+    #                             "SlotName": "stor-slot1",
+    #                         },
+    #                     }
+    #                 ]
+    #             },
+    #         }
+    #     ]
+    # )
+    # def test_duplicate_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
+    #     mocker.patch(
+    #         MODULE_PATH + 'get_device_type',
+    #         return_value=params.get('storageslots')
+    #     )
+    #     ome_response_mock.json_data = params["bladeslots"]
+    #     ch_slots = params['slot_options']
+    #     f_module = self.get_module_mock()
 
-        with pytest.raises(AnsibleFailJSonException) as exc_info:
-            self.module.get_slot_data(
-                f_module,
-                ome_connection_mock_for_chassis_slots,
-                ch_slots,
-                params['chass_id']
-            )
+    #     with pytest.raises(AnsibleFailJSonException) as exc_info:
+    #         self.module.get_slot_data(
+    #             f_module,
+    #             ome_connection_mock_for_chassis_slots,
+    #             ch_slots,
+    #             params['chass_id']
+    #         )
 
-        expected_msg = SLOT_NUM_DUP.format(params['invalid_list'])
-        assert str(exc_info.value) == expected_msg
+    #     expected_msg = SLOT_NUM_DUP.format(params['invalid_list'])
+    #     assert str(exc_info.value) == expected_msg

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -20,7 +20,7 @@ from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import ConnectionError, SSLValidationError
 from ansible.module_utils._text import to_text
 from ansible_collections.dellemc.openmanage.plugins.modules import ome_chassis_slots
-from ansible_collections.dellemc.openmanage.tests.unit.plugins.modules.common import FakeAnsibleModule
+from ansible_collections.dellemc.openmanage.tests.unit.plugins.modules.common import FakeAnsibleModule, AnsibleFailJSonException
 
 DEVICE_REPEATED = "Duplicate device entry found for devices with identifiers {0}."
 CHASSIS_REPEATED = "Duplicate chassis entry found for chassis with service tags {0}."
@@ -34,6 +34,8 @@ SUCCESS_REFRESH_MSG = "The rename slot job(s) completed successfully. " \
 FAILED_MSG = "Failed to rename {0} of {1} slot names."
 NO_CHANGES_MSG = "No changes found to be applied."
 CHANGES_FOUND = "Changes found to be applied."
+INVALID_SLOT_NUMBERS = "Unable to rename one or more slots because the slot number(s) are invalid: {0}."
+SLOT_NUM_DUP = "Slot numbers are repeated for chassis {0}."
 
 MODULE_PATH = 'ansible_collections.dellemc.openmanage.plugins.modules.ome_chassis_slots.'
 MODULE_UTIL_PATH = 'ansible_collections.dellemc.openmanage.plugins.module_utils.ome.'
@@ -424,3 +426,74 @@ class TestOmeChassisSlots(FakeAnsibleModule):
         result = self._run_module(ome_default_args)
         assert result['msg'] == params['message'].format(
             ';'.join(set(params.get("invalid_list"))))
+
+    @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
+                                                          "slots": [{"slot_name": "t1", "slot_number": 1},
+                                                                    {"slot_name": "s1", "slot_number": 5},
+                                                                    {"slot_name": "s2", "slot_number": 6}]},
+                                         "chass_id": 1234, "chassi": {'value': [{"Identifier": "ABC1234", "Id": 1234}]},
+                                         "bladeslots": {'value': [{"SlotNumber": "1", "SlotName": "blade-slot1",
+                                                                   "Id": 234}]},
+                                         "invalid_list": {"6"},
+                                         "message": INVALID_SLOT_NUMBERS,
+                                         "storageslots": {'value': [{"ChassisServiceTag": "ABC1234",
+                                                                     "SlotConfiguration": {
+                                                                         "SlotId": "123", "SlotNumber": "5",
+                                                                         "SlotName": "stor-slot1"}}]},
+                                         "slot_dict_diff": {'ABC1234_5': {'SlotNumber': '5', 'SlotName': 'stor-slot1',
+                                                                          'ChassisId': 1234, 'SlotId': "123",
+                                                                          'ChassisServiceTag': 'ABC1234',
+                                                                          'new_name': 's1'},
+                                                            'ABC1234_1': {'SlotNumber': '1', 'SlotName': 'blade-slot1',
+                                                                          'ChassisId': 1234, 'SlotId': "234",
+                                                                          "Id": 234,
+                                                                          'ChassisServiceTag': 'ABC1234',
+                                                                          'new_name': 't1'}}}])
+    def test_invalid_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
+        mocker.patch(
+            MODULE_PATH + 'get_device_type',
+            return_value=params.get('storageslots'))
+        ome_response_mock.json_data = params["bladeslots"]
+        ch_slots = params['slot_options']
+        f_module = self.get_module_mock()
+        with pytest.raises(AnsibleFailJSonException) as exc_info:
+            self.module.get_slot_data(f_module, ome_connection_mock_for_chassis_slots, ch_slots, params['chass_id'])
+
+        # Validate the error message
+        expected_msg = INVALID_SLOT_NUMBERS.format(';'.join(params['invalid_list']))
+        assert str(exc_info.value) == expected_msg
+
+    @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
+                                                        "slots": [{"slot_name": "t1", "slot_number": 1},
+                                                                {"slot_name": "s1", "slot_number": 5},
+                                                                {"slot_name": "s1", "slot_number": 5}]},
+                                        "chass_id": 1234, "chassi": {'value': [{"Identifier": "ABC1234", "Id": 1234}]},
+                                        "bladeslots": {'value': [{"SlotNumber": "1", "SlotName": "blade-slot1",
+                                                                "Id": 234}]},
+                                        "invalid_list": "ABC1234",
+                                        "storageslots": {'value': [{"ChassisServiceTag": "ABC1234",
+                                                                    "SlotConfiguration": {
+                                                                        "SlotId": "123", "SlotNumber": "5",
+                                                                        "SlotName": "stor-slot1"}}]},
+                                        "slot_dict_diff": {'ABC1234_5': {'SlotNumber': '5', 'SlotName': 'stor-slot1',
+                                                                        'ChassisId': 1234, 'SlotId': "123",
+                                                                        'ChassisServiceTag': 'ABC1234',
+                                                                        'new_name': 's1'},
+                                                        'ABC1234_1': {'SlotNumber': '1', 'SlotName': 'blade-slot1',
+                                                                        'ChassisId': 1234, 'SlotId': "234",
+                                                                        "Id": 234,
+                                                                        'ChassisServiceTag': 'ABC1234',
+                                                                        'new_name': 't1'}}}])
+    def test_duplicate_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
+        mocker.patch(
+            MODULE_PATH + 'get_device_type',
+            return_value=params.get('storageslots'))
+        ome_response_mock.json_data = params["bladeslots"]
+        ch_slots = params['slot_options']
+        f_module = self.get_module_mock()
+        with pytest.raises(AnsibleFailJSonException) as exc_info:
+            self.module.get_slot_data(f_module, ome_connection_mock_for_chassis_slots, ch_slots, params['chass_id'])
+
+        # Validate the error message
+        expected_msg = SLOT_NUM_DUP.format(params['invalid_list'])
+        assert str(exc_info.value) == expected_msg

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -2,8 +2,8 @@
 
 #
 # Dell OpenManage Ansible Modules
-# Version 7.0.0
-# Copyright (C) 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Version 10.1.0
+# Copyright (C) 2021-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
@@ -93,7 +93,7 @@ class TestOmeChassisSlots(FakeAnsibleModule):
         ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params[
             'json_data']
         ome_default_args.update(params['mparams'])
-        result = self._run_module_with_fail_json(ome_default_args)
+        result = self._run_module(ome_default_args)
         assert result['msg'] == params['message'].format(
             ';'.join(set(params.get("invalid_list"))))
 
@@ -286,12 +286,12 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             mocker.patch(
                 MODULE_PATH + 'get_device_slot_config',
                 side_effect=exc_type("exception message"))
-            result = self._run_module_with_fail_json(ome_default_args)
+            result = self._run_module(ome_default_args)
             assert result['failed'] is True
         else:
             mocker.patch(MODULE_PATH + 'get_device_slot_config',
                          side_effect=exc_type('https://testhost.com', 400, 'http error message',
                                               {"accept-type": "application/json"}, StringIO(json_str)))
-            result = self._run_module_with_fail_json(ome_default_args)
+            result = self._run_module(ome_default_args)
             assert result['failed'] is True
         assert 'msg' in result

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -110,13 +110,15 @@ class TestOmeChassisSlots(FakeAnsibleModule):
         "success": True},
         {
         "mparams": {"slot_options": [{"chassis_service_tag": "ABC1234",
-                        "slots": [{"slot_name": "t1", "slot_number": 1}, {"slot_name": "s1", "slot_number": 5}]},
-                                  {"chassis_service_tag": "ABC1234", "slots": [{"slot_name": "t2", "slot_number": 2}, {"slot_name": "s2", "slot_number": 6}]}]},
+                                      "slots": [{"slot_name": "t1", "slot_number": 1}, {"slot_name": "s1", "slot_number": 5}]},
+                                     {"chassis_service_tag": "ABC1234",
+                                      "slots": [{"slot_name": "t2", "slot_number": 2}, {"slot_name": "s2", "slot_number": 6}]}]},
         "invalid_list": {"ABC1234"},
         "json_data": {
             "value": [
                     {"Id": 10053, "Identifier": "2H5DNX2", "SlotConfiguration": {"ChassisName": None}},
-                    {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234", "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1", "SlotName": "my_840c", "SlotType": "2000"}}]},
+                    {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
+                     "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1", "SlotName": "my_840c", "SlotType": "2000"}}]},
         "message": CHASSIS_REPEATED,
         "success": True},
         {
@@ -136,7 +138,7 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                         {"slot_name": "s2", "slot_number": 6},
                     ],
                 },
-                ]},
+            ]},
         "invalid_list": {"ABC1234"},
         "json_data": {
             "value": [

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -324,181 +324,157 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             assert result['failed'] is True
         assert 'msg' in result
 
-    # @pytest.mark.parametrize(
-    #     "params",
-    #     [
-    #         {
-    #             "mparams": {
-    #                 "slot_options": [
-    #                     {
-    #                         "chassis_service_tag": "ABC1234",
-    #                         "slots": [
-    #                             {"slot_name": "t1", "slot_number": 1},
-    #                             {"slot_name": "s1", "slot_number": 5},
-    #                         ],
-    #                     },
-    #                     {
-    #                         "chassis_service_tag": "ABC1234",
-    #                         "slots": [
-    #                             {"slot_name": "t2", "slot_number": 2},
-    #                             {"slot_name": "s2", "slot_number": 6},
-    #                         ],
-    #                     },
-    #                 ]
-    #             },
-    #             "invalid_list": {"ABC1234"},
-    #             "json_data": {
-    #                 "value": [
-    #                     {
-    #                         "Id": 10053,
-    #                         "Identifier": "2H5DNX2",
-    #                         "SlotConfiguration": {"ChassisName": None},
-    #                     },
-    #                     {
-    #                         "Id": 10054,
-    #                         "Type": 1000,
-    #                         "Identifier": "ABCD1234",
-    #                         "SlotConfiguration": {
-    #                             "DeviceType": "1000",
-    #                             "ChassisId": "10053",
-    #                             "SlotNumber": "1",
-    #                             "SlotName": "my_840c",
-    #                             "SlotType": "2000",
-    #                         },
-    #                     },
-    #                 ]
-    #             },
-    #             "message": CHASSIS_REPEATED,
-    #             "success": True,
-    #         },
-    #         {
-    #             "mparams": {
-    #                 "slot_options": [
-    #                     {
-    #                         "chassis_service_tag": "ABC1234",
-    #                         "slots": [
-    #                             {"slot_name": "t1", "slot_number": 1},
-    #                             {"slot_name": "s1", "slot_number": 5},
-    #                         ],
-    #                     },
-    #                     {
-    #                         "chassis_service_tag": "ABC1235",
-    #                         "slots": [
-    #                             {"slot_name": "t2", "slot_number": 2},
-    #                             {"slot_name": "s2", "slot_number": 6},
-    #                         ],
-    #                     },
-    #                 ]
-    #             },
-    #             "invalid_list": {"ABC1234"},
-    #             "json_data": {
-    #                 "value": [
-    #                     {
-    #                         "Id": 10053,
-    #                         "Identifier": "2H5DNX2",
-    #                         "SlotConfiguration": {"ChassisName": None},
-    #                     },
-    #                     {
-    #                         "Id": 10054,
-    #                         "Type": 1000,
-    #                         "Identifier": "ABCD1234",
-    #                         "SlotConfiguration": {
-    #                             "DeviceType": "1000",
-    #                             "ChassisId": "10053",
-    #                             "SlotNumber": "1",
-    #                             "SlotName": "my_840c",
-    #                             "SlotType": "2000",
-    #                         },
-    #                     },
-    #                 ]
-    #             },
-    #             "message": CHASSIS_TAG_INVALID,
-    #             "success": True,
-    #         },
-    #     ]
-    # )
-    # def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
-    #     ome_response_mock.success = params.get("success", True)
-    #     ome_response_mock.json_data = params["json_data"]
-    #     ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params["json_data"]
-    #     ome_default_args.update(params["mparams"])
-    #     result = self._run_module(ome_default_args)
-    #     assert result["msg"] == params["message"].format(';'.join(set(params.get("invalid_list"))))
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {
+                "mparams": {
+                    "slot_options": [
+                        {
+                            "chassis_service_tag": "ABC1234",
+                            "slots": [
+                                {"slot_name": "t1", "slot_number": 1},
+                                {"slot_name": "s1", "slot_number": 5},
+                            ],
+                        },
+                        {
+                            "chassis_service_tag": "ABC1234",
+                            "slots": [
+                                {"slot_name": "t2", "slot_number": 2},
+                                {"slot_name": "s2", "slot_number": 6},
+                            ],
+                        },
+                    ]
+                },
+                "invalid_list": {"ABC1234"},
+                "json_data": {
+                    "value": [
+                        {
+                            "Id": 10053,
+                            "Identifier": "2H5DNX2",
+                            "SlotConfiguration": {"ChassisName": None},
+                        },
+                        {
+                            "Id": 10054,
+                            "Type": 1000,
+                            "Identifier": "ABCD1234",
+                            "SlotConfiguration": {
+                                "DeviceType": "1000",
+                                "ChassisId": "10053",
+                                "SlotNumber": "1",
+                                "SlotName": "my_840c",
+                                "SlotType": "2000",
+                            },
+                        },
+                    ]
+                },
+                "message": CHASSIS_REPEATED,
+                "success": True,
+            },
+            {
+                "mparams": {
+                    "slot_options": [
+                        {
+                            "chassis_service_tag": "ABC1234",
+                            "slots": [
+                                {"slot_name": "t1", "slot_number": 1},
+                                {"slot_name": "s1", "slot_number": 5},
+                            ],
+                        },
+                        {
+                            "chassis_service_tag": "ABC1235",
+                            "slots": [
+                                {"slot_name": "t2", "slot_number": 2},
+                                {"slot_name": "s2", "slot_number": 6},
+                            ],
+                        },
+                    ]
+                },
+                "invalid_list": {"ABC1234"},
+                "json_data": {
+                    "value": [
+                        {
+                            "Id": 10053,
+                            "Identifier": "2H5DNX2",
+                            "SlotConfiguration": {"ChassisName": None},
+                        },
+                        {
+                            "Id": 10054,
+                            "Type": 1000,
+                            "Identifier": "ABCD1234",
+                            "SlotConfiguration": {
+                                "DeviceType": "1000",
+                                "ChassisId": "10053",
+                                "SlotNumber": "1",
+                                "SlotName": "my_840c",
+                                "SlotType": "2000",
+                            },
+                        },
+                    ]
+                },
+                "message": CHASSIS_TAG_INVALID,
+                "success": True,
+            },
+        ]
+    )
+    def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
+        ome_response_mock.success = params.get("success", True)
+        ome_response_mock.json_data = params["json_data"]
+        ome_connection_mock_for_chassis_slots.get_all_items_with_pagination.return_value = params["json_data"]
+        ome_default_args.update(params["mparams"])
+        result = self._run_module(ome_default_args)
+        assert result["msg"] == params["message"].format(';'.join(set(params.get("invalid_list"))))
 
-    # @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
-    #                                                       "slots": [{"slot_name": "t1", "slot_number": 1},
-    #                                                                 {"slot_name": "s1", "slot_number": 5},
-    #                                                                 {"slot_name": "s2", "slot_number": 6}]},
-    #                                      "chass_id": 1234, "chassi": {'value': [{"Identifier": "ABC1234", "Id": 1234}]},
-    #                                      "bladeslots": {'value': [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
-    #                                      "invalid_list": {"6"},
-    #                                      "message": INVALID_SLOT_NUMBERS,
-    #                                      "storageslots": {'value': [{"ChassisServiceTag": "ABC1234",
-    #                                                                  "SlotConfiguration": {
-    #                                                                      "SlotId": "123", "SlotNumber": "5",
-    #                                                                      "SlotName": "stor-slot1"}}]},
-    #                                      }])
-    # def test_invalid_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
-    #     mocker.patch(
-    #         MODULE_PATH + 'get_device_type',
-    #         return_value=params.get('storageslots'))
-    #     ome_response_mock.json_data = params["bladeslots"]
-    #     ch_slots = params['slot_options']
-    #     f_module = self.get_module_mock()
-    #     with pytest.raises(AnsibleFailJSonException) as exc_info:
-    #         self.module.get_slot_data(f_module, ome_connection_mock_for_chassis_slots, ch_slots, params['chass_id'])
+    @pytest.mark.parametrize("params", [{"slot_options": {"chassis_service_tag": "ABC1234",
+                                                          "slots": [{"slot_name": "t1", "slot_number": 1},
+                                                                    {"slot_name": "s1", "slot_number": 5},
+                                                                    {"slot_name": "s2", "slot_number": 6}]},
+                                         "chass_id": 1234, "chassi": {'value': [{"Identifier": "ABC1234", "Id": 1234}]},
+                                         "bladeslots": {'value': [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
+                                         "invalid_list": {"6"},
+                                         "message": INVALID_SLOT_NUMBERS,
+                                         "storageslots": {'value': [{"ChassisServiceTag": "ABC1234",
+                                                                     "SlotConfiguration": {
+                                                                         "SlotId": "123", "SlotNumber": "5",
+                                                                         "SlotName": "stor-slot1"}}]},
+                                         },
+                                         {
+                                            "slot_options": {
+                                                "chassis_service_tag": "ABC1234",
+                                                "slots": [
+                                                    {"slot_name": "t1", "slot_number": 1},
+                                                    {"slot_name": "s1", "slot_number": 5},
+                                                    {"slot_name": "s1", "slot_number": 5},
+                                                ],
+                                            },
+                                            "chass_id": 1234,
+                                            "chassi": {"value": [{"Identifier": "ABC1234", "Id": 1234}]},
+                                            "bladeslots": {"value": [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
+                                            "invalid_list": {"ABC1234"},
+                                            "message": SLOT_NUM_DUP,
+                                            "storageslots": {
+                                                "value": [
+                                                    {
+                                                        "ChassisServiceTag": "ABC1234",
+                                                        "SlotConfiguration": {
+                                                            "SlotId": "123",
+                                                            "SlotNumber": "5",
+                                                            "SlotName": "stor-slot1",
+                                                        },
+                                                    }
+                                                ]
+                                            },
+                                         }])
+    def test_invalid_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
+        mocker.patch(
+            MODULE_PATH + 'get_device_type',
+            return_value=params.get('storageslots'))
+        ome_response_mock.json_data = params["bladeslots"]
+        ch_slots = params['slot_options']
+        f_module = self.get_module_mock()
+        with pytest.raises(AnsibleFailJSonException) as exc_info:
+            self.module.get_slot_data(f_module, ome_connection_mock_for_chassis_slots, ch_slots, params['chass_id'])
 
-    #     # Validate the error message
-    #     expected_msg = INVALID_SLOT_NUMBERS.format(';'.join(params['invalid_list']))
-    #     assert str(exc_info.value) == expected_msg
-
-    # @pytest.mark.parametrize(
-    #     "params",
-    #     [
-    #         {
-    #             "slot_options": {
-    #                 "chassis_service_tag": "ABC1234",
-    #                 "slots": [
-    #                     {"slot_name": "t1", "slot_number": 1},
-    #                     {"slot_name": "s1", "slot_number": 5},
-    #                     {"slot_name": "s1", "slot_number": 5},
-    #                 ],
-    #             },
-    #             "chass_id": 1234,
-    #             "chassi": {"value": [{"Identifier": "ABC1234", "Id": 1234}]},
-    #             "bladeslots": {"value": [{"SlotNumber": "1", "SlotName": "blade-slot1", "Id": 234}]},
-    #             "invalid_list": "ABC1234",
-    #             "storageslots": {
-    #                 "value": [
-    #                     {
-    #                         "ChassisServiceTag": "ABC1234",
-    #                         "SlotConfiguration": {
-    #                             "SlotId": "123",
-    #                             "SlotNumber": "5",
-    #                             "SlotName": "stor-slot1",
-    #                         },
-    #                     }
-    #                 ]
-    #             },
-    #         }
-    #     ]
-    # )
-    # def test_duplicate_slot_numbers(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, mocker):
-    #     mocker.patch(
-    #         MODULE_PATH + 'get_device_type',
-    #         return_value=params.get('storageslots')
-    #     )
-    #     ome_response_mock.json_data = params["bladeslots"]
-    #     ch_slots = params['slot_options']
-    #     f_module = self.get_module_mock()
-
-    #     with pytest.raises(AnsibleFailJSonException) as exc_info:
-    #         self.module.get_slot_data(
-    #             f_module,
-    #             ome_connection_mock_for_chassis_slots,
-    #             ch_slots,
-    #             params['chass_id']
-    #         )
-
-    #     expected_msg = SLOT_NUM_DUP.format(params['invalid_list'])
-    #     assert str(exc_info.value) == expected_msg
+        # Validate the error message
+        expected_msg = params['message'].format(';'.join(params['invalid_list']))
+        assert str(exc_info.value) == expected_msg

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -109,92 +109,58 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                                              "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': NO_CHANGES_MSG,
         "success": True},
         {
-            "mparams": {
-                "slot_options": [
-                    {
-                        "chassis_service_tag": "ABC1234",
-                        "slots": [
-                            {"slot_name": "t1", "slot_number": 1},
-                            {"slot_name": "s1", "slot_number": 5},
-                        ],
-                    },
-                    {
-                        "chassis_service_tag": "ABC1234",
-                        "slots": [
-                            {"slot_name": "t2", "slot_number": 2},
-                            {"slot_name": "s2", "slot_number": 6},
-                        ],
-                    },
-                ]
-            },
-            "invalid_list": {"ABC1234"},
-            "json_data": {
-                "value": [
-                    {
-                        "Id": 10053,
-                        "Identifier": "2H5DNX2",
-                        "SlotConfiguration": {"ChassisName": None},
-                    },
-                    {
-                        "Id": 10054,
-                        "Type": 1000,
-                        "Identifier": "ABCD1234",
-                        "SlotConfiguration": {
-                            "DeviceType": "1000",
-                            "ChassisId": "10053",
-                            "SlotNumber": "1",
-                            "SlotName": "my_840c",
-                            "SlotType": "2000",
-                        },
-                    },
-                ]
-            },
-            "message": CHASSIS_REPEATED,
-            "success": True,
-        },
+        "mparams": {"slot_options": [{"chassis_service_tag": "ABC1234",
+                        "slots": [{"slot_name": "t1", "slot_number": 1}, {"slot_name": "s1", "slot_number": 5}]},
+                                  {"chassis_service_tag": "ABC1234", "slots": [{"slot_name": "t2", "slot_number": 2}, {"slot_name": "s2", "slot_number": 6}]}]},
+        "invalid_list": {"ABC1234"},
+        "json_data": {
+            "value": [
+                    {"Id": 10053, "Identifier": "2H5DNX2", "SlotConfiguration": {"ChassisName": None}},
+                    {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234", "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1", "SlotName": "my_840c", "SlotType": "2000"}}]},
+        "message": CHASSIS_REPEATED,
+        "success": True},
         {
-            "mparams": {
-                "slot_options": [
-                    {
-                        "chassis_service_tag": "ABC1234",
-                        "slots": [
-                            {"slot_name": "t1", "slot_number": 1},
-                            {"slot_name": "s1", "slot_number": 5},
-                        ],
+        "mparams": {
+            "slot_options": [
+                {
+                    "chassis_service_tag": "ABC1234",
+                    "slots": [
+                        {"slot_name": "t1", "slot_number": 1},
+                        {"slot_name": "s1", "slot_number": 5},
+                    ],
+                },
+                {
+                    "chassis_service_tag": "ABC1235",
+                    "slots": [
+                        {"slot_name": "t2", "slot_number": 2},
+                        {"slot_name": "s2", "slot_number": 6},
+                    ],
+                },
+                ]},
+        "invalid_list": {"ABC1234"},
+        "json_data": {
+            "value": [
+                {
+                    "Id": 10053,
+                    "Identifier": "2H5DNX2",
+                    "SlotConfiguration": {"ChassisName": None},
+                },
+                {
+                    "Id": 10054,
+                    "Type": 1000,
+                    "Identifier": "ABCD1234",
+                    "SlotConfiguration": {
+                        "DeviceType": "1000",
+                        "ChassisId": "10053",
+                        "SlotNumber": "1",
+                        "SlotName": "my_840c",
+                        "SlotType": "2000",
                     },
-                    {
-                        "chassis_service_tag": "ABC1235",
-                        "slots": [
-                            {"slot_name": "t2", "slot_number": 2},
-                            {"slot_name": "s2", "slot_number": 6},
-                        ],
-                    },
-                ]
-            },
-            "invalid_list": {"ABC1234"},
-            "json_data": {
-                "value": [
-                    {
-                        "Id": 10053,
-                        "Identifier": "2H5DNX2",
-                        "SlotConfiguration": {"ChassisName": None},
-                    },
-                    {
-                        "Id": 10054,
-                        "Type": 1000,
-                        "Identifier": "ABCD1234",
-                        "SlotConfiguration": {
-                            "DeviceType": "1000",
-                            "ChassisId": "10053",
-                            "SlotNumber": "1",
-                            "SlotName": "my_840c",
-                            "SlotType": "2000",
-                        },
-                    },
-                ]
-            },
-            "message": CHASSIS_TAG_INVALID,
-            "success": True,
+                },
+            ]
+        },
+        "message": CHASSIS_TAG_INVALID,
+        "success": True,
         }
     ])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -104,8 +104,8 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
                       {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
                       {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234"}]}, 'message': INVALID_SLOT_DEVICE,
-        "success": True},{
-        'mparams': {"device_options": [{"slot_name": "s2","device_id": 10054}]},
+        "success": True}, {
+        'mparams': {"device_options": [{"slot_name": "s2", "device_id": 10054}]},
         "invalid_list": set(["10054"]), "json_data": {
             "value": [{"Id": 10053, "Identifier": "2H5DNX2"},
                       {"Id": 10052, "Type": 1000, "Identifier": "PQRS1234"},
@@ -321,57 +321,99 @@ class TestOmeChassisSlots(FakeAnsibleModule):
             assert result['failed'] is True
         assert 'msg' in result
 
-    @pytest.mark.parametrize("params", [
-        {'mparams': {"slot_options": [
-                                        {
-                                            "chassis_service_tag": "ABC1234",
-                                            "slots": [
-                                                {"slot_name": "t1", "slot_number": 1},
-                                                {"slot_name": "s1", "slot_number": 5}
-                                            ]
-                                        },
-                                        {
-                                            "chassis_service_tag": "ABC1234",
-                                            "slots": [
-                                                {"slot_name": "t2", "slot_number": 2},
-                                                {"slot_name": "s2", "slot_number": 6}
-                                            ]
-                                        },
-                                    ]
-                                },
-         "invalid_list": set(["ABC1234"]),
-         "json_data":
-         {"value": [{"Id": 10053, "Identifier": "2H5DNX2",
-                     "SlotConfiguration": {"ChassisName": None}},
-                    {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
-                     "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
-                                           "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': CHASSIS_REPEATED,
-         "success": True},
-        {'mparams': {"slot_options": [
-                                        {
-                                            "chassis_service_tag": "ABC1234",
-                                            "slots": [
-                                                {"slot_name": "t1", "slot_number": 1},
-                                                {"slot_name": "s1", "slot_number": 5}
-                                            ]
-                                        },
-                                        {
-                                            "chassis_service_tag": "ABC1235",
-                                            "slots": [
-                                                {"slot_name": "t2", "slot_number": 2},
-                                                {"slot_name": "s2", "slot_number": 6}
-                                            ]
-                                        },
-                                    ]
-                    },
-        "invalid_list": set(["ABC1234"]),
-        "json_data":
-        {"value": [{"Id": 10053, "Identifier": "2H5DNX2",
-                     "SlotConfiguration": {"ChassisName": None}},
-                    {"Id": 10054, "Type": 1000, "Identifier": "ABCD1234",
-                     "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
-                                           "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': CHASSIS_TAG_INVALID,
-        "success": True}])
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {
+                "mparams": {
+                    "slot_options": [
+                        {
+                            "chassis_service_tag": "ABC1234",
+                            "slots": [
+                                {"slot_name": "t1", "slot_number": 1},
+                                {"slot_name": "s1", "slot_number": 5},
+                            ],
+                        },
+                        {
+                            "chassis_service_tag": "ABC1234",
+                            "slots": [
+                                {"slot_name": "t2", "slot_number": 2},
+                                {"slot_name": "s2", "slot_number": 6},
+                            ],
+                        },
+                    ]
+                },
+                "invalid_list": {"ABC1234"},
+                "json_data": {
+                    "value": [
+                        {
+                            "Id": 10053,
+                            "Identifier": "2H5DNX2",
+                            "SlotConfiguration": {"ChassisName": None},
+                        },
+                        {
+                            "Id": 10054,
+                            "Type": 1000,
+                            "Identifier": "ABCD1234",
+                            "SlotConfiguration": {
+                                "DeviceType": "1000",
+                                "ChassisId": "10053",
+                                "SlotNumber": "1",
+                                "SlotName": "my_840c",
+                                "SlotType": "2000",
+                            },
+                        },
+                    ]
+                },
+                "message": CHASSIS_REPEATED,
+                "success": True,
+            },
+            {
+                "mparams": {
+                    "slot_options": [
+                        {
+                            "chassis_service_tag": "ABC1234",
+                            "slots": [
+                                {"slot_name": "t1", "slot_number": 1},
+                                {"slot_name": "s1", "slot_number": 5},
+                            ],
+                        },
+                        {
+                            "chassis_service_tag": "ABC1235",
+                            "slots": [
+                                {"slot_name": "t2", "slot_number": 2},
+                                {"slot_name": "s2", "slot_number": 6},
+                            ],
+                        },
+                    ]
+                },
+                "invalid_list": {"ABC1234"},
+                "json_data": {
+                    "value": [
+                        {
+                            "Id": 10053,
+                            "Identifier": "2H5DNX2",
+                            "SlotConfiguration": {"ChassisName": None},
+                        },
+                        {
+                            "Id": 10054,
+                            "Type": 1000,
+                            "Identifier": "ABCD1234",
+                            "SlotConfiguration": {
+                                "DeviceType": "1000",
+                                "ChassisId": "10053",
+                                "SlotNumber": "1",
+                                "SlotName": "my_840c",
+                                "SlotType": "2000",
+                            },
+                        },
+                    ]
+                },
+                "message": CHASSIS_TAG_INVALID,
+                "success": True,
+            },
+        ]
+    )
     def test_get_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock,
                                     ome_default_args, module_mock):
         ome_response_mock.success = params.get("success", True)

--- a/tests/unit/plugins/modules/test_ome_chassis_slots.py
+++ b/tests/unit/plugins/modules/test_ome_chassis_slots.py
@@ -108,94 +108,94 @@ class TestOmeChassisSlots(FakeAnsibleModule):
                        "SlotConfiguration": {"DeviceType": "1000", "ChassisId": "10053", "SlotNumber": "1",
                                              "SlotName": "my_840c", "SlotType": "2000"}}]}, 'message': NO_CHANGES_MSG,
         "success": True},
-    {
-        "mparams": {
-            "slot_options": [
-                {
-                    "chassis_service_tag": "ABC1234",
-                    "slots": [
-                        {"slot_name": "t1", "slot_number": 1},
-                        {"slot_name": "s1", "slot_number": 5},
-                    ],
-                },
-                {
-                    "chassis_service_tag": "ABC1234",
-                    "slots": [
-                        {"slot_name": "t2", "slot_number": 2},
-                        {"slot_name": "s2", "slot_number": 6},
-                    ],
-                },
-            ]
-        },
-        "invalid_list": {"ABC1234"},
-        "json_data": {
-            "value": [
-                {
-                    "Id": 10053,
-                    "Identifier": "2H5DNX2",
-                    "SlotConfiguration": {"ChassisName": None},
-                },
-                {
-                    "Id": 10054,
-                    "Type": 1000,
-                    "Identifier": "ABCD1234",
-                    "SlotConfiguration": {
-                        "DeviceType": "1000",
-                        "ChassisId": "10053",
-                        "SlotNumber": "1",
-                        "SlotName": "my_840c",
-                        "SlotType": "2000",
+        {
+            "mparams": {
+                "slot_options": [
+                    {
+                        "chassis_service_tag": "ABC1234",
+                        "slots": [
+                            {"slot_name": "t1", "slot_number": 1},
+                            {"slot_name": "s1", "slot_number": 5},
+                        ],
                     },
-                },
-            ]
-        },
-        "message": CHASSIS_REPEATED,
-        "success": True,
-    },
-    {
-        "mparams": {
-            "slot_options": [
-                {
-                    "chassis_service_tag": "ABC1234",
-                    "slots": [
-                        {"slot_name": "t1", "slot_number": 1},
-                        {"slot_name": "s1", "slot_number": 5},
-                    ],
-                },
-                {
-                    "chassis_service_tag": "ABC1235",
-                    "slots": [
-                        {"slot_name": "t2", "slot_number": 2},
-                        {"slot_name": "s2", "slot_number": 6},
-                    ],
-                },
-            ]
-        },
-        "invalid_list": {"ABC1234"},
-        "json_data": {
-            "value": [
-                {
-                    "Id": 10053,
-                    "Identifier": "2H5DNX2",
-                    "SlotConfiguration": {"ChassisName": None},
-                },
-                {
-                    "Id": 10054,
-                    "Type": 1000,
-                    "Identifier": "ABCD1234",
-                    "SlotConfiguration": {
-                        "DeviceType": "1000",
-                        "ChassisId": "10053",
-                        "SlotNumber": "1",
-                        "SlotName": "my_840c",
-                        "SlotType": "2000",
+                    {
+                        "chassis_service_tag": "ABC1234",
+                        "slots": [
+                            {"slot_name": "t2", "slot_number": 2},
+                            {"slot_name": "s2", "slot_number": 6},
+                        ],
                     },
-                },
-            ]
+                ]
+            },
+            "invalid_list": {"ABC1234"},
+            "json_data": {
+                "value": [
+                    {
+                        "Id": 10053,
+                        "Identifier": "2H5DNX2",
+                        "SlotConfiguration": {"ChassisName": None},
+                    },
+                    {
+                        "Id": 10054,
+                        "Type": 1000,
+                        "Identifier": "ABCD1234",
+                        "SlotConfiguration": {
+                            "DeviceType": "1000",
+                            "ChassisId": "10053",
+                            "SlotNumber": "1",
+                            "SlotName": "my_840c",
+                            "SlotType": "2000",
+                        },
+                    },
+                ]
+            },
+            "message": CHASSIS_REPEATED,
+            "success": True,
         },
-        "message": CHASSIS_TAG_INVALID,
-        "success": True,
-    }])
+        {
+            "mparams": {
+                "slot_options": [
+                    {
+                        "chassis_service_tag": "ABC1234",
+                        "slots": [
+                            {"slot_name": "t1", "slot_number": 1},
+                            {"slot_name": "s1", "slot_number": 5},
+                        ],
+                    },
+                    {
+                        "chassis_service_tag": "ABC1235",
+                        "slots": [
+                            {"slot_name": "t2", "slot_number": 2},
+                            {"slot_name": "s2", "slot_number": 6},
+                        ],
+                    },
+                ]
+            },
+            "invalid_list": {"ABC1234"},
+            "json_data": {
+                "value": [
+                    {
+                        "Id": 10053,
+                        "Identifier": "2H5DNX2",
+                        "SlotConfiguration": {"ChassisName": None},
+                    },
+                    {
+                        "Id": 10054,
+                        "Type": 1000,
+                        "Identifier": "ABCD1234",
+                        "SlotConfiguration": {
+                            "DeviceType": "1000",
+                            "ChassisId": "10053",
+                            "SlotNumber": "1",
+                            "SlotName": "my_840c",
+                            "SlotType": "2000",
+                        },
+                    },
+                ]
+            },
+            "message": CHASSIS_TAG_INVALID,
+            "success": True,
+        }])
     def test_get_device_slot_config_errors(self, params, ome_connection_mock_for_chassis_slots, ome_response_mock, ome_default_args, module_mock):
         # Test device slot config error
         result = self._run_config_error_test(params, ome_response_mock, ome_connection_mock_for_chassis_slots, ome_default_args)


### PR DESCRIPTION
# Description
PR is raised to replace the fail_json with exit_json with failed as True

# ISSUE TYPE
- Feature Pull Request

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

<img width="1640" height="842" alt="image" src="https://github.com/user-attachments/assets/02dcfe46-244b-453c-8b7f-e37da7195b29" />

