### PR TITLE
[BUG][idrac_system_info] Check chassis sensor collection before accessing any sensor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,4 @@
 # Vasanth Ds (Vasanth_Sathyanaraya@Dell.com)
 
 # for all files:
-* @Kritika-Bhateja-03 @shenda1 @sapana05 @MangirishK @Sakshi-dell @Krunal-Thakkar
-  @rounak-adhikary @Bhavneet-Sharma @meenakshidembi691 @trisha-dell @Saksham-Nautiyal
-  @AnikaAgiwal2711 @subrahmanyam-a @ShrinidhiRao15
+* @Kritika-Bhateja-03 @shenda1 @sapana05 @MangirishK @Sakshi-dell @Krunal-Thakkar @rounak-adhikary @Bhavneet-Sharma @meenakshidembi691 @trisha-dell @Saksham-Nautiyal @AnikaAgiwal2711 @subrahmanyam-a @ShrinidhiRao15

--- a/plugins/module_utils/idrac_utils/info/chassis_sensor_util.py
+++ b/plugins/module_utils/idrac_utils/info/chassis_sensor_util.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Dell OpenManage Ansible Modules
-# Version 10.0.0
+# Version 10.0.1
 # Copyright (C) 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 # Redistribution and use in source and binary forms, with or without modification,

--- a/plugins/module_utils/idrac_utils/info/chassis_sensor_util.py
+++ b/plugins/module_utils/idrac_utils/info/chassis_sensor_util.py
@@ -26,9 +26,11 @@
 
 GET_IDRAC_SENSORS_URI = "/redfish/v1/Chassis/System.Embedded.1/Sensors"
 
+
 class _chassis_response(object):
     def __init__(self, status_code: int):
         self.status_code = status_code
+
 
 class IDRACChassisSensors(object):
     def __init__(self, idrac):

--- a/plugins/module_utils/idrac_utils/info/chassis_sensor_util.py
+++ b/plugins/module_utils/idrac_utils/info/chassis_sensor_util.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+# Dell OpenManage Ansible Modules
+# Version 10.0.0
+# Copyright (C) 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+
+#    * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+GET_IDRAC_SENSORS_URI = "/redfish/v1/Chassis/System.Embedded.1/Sensors"
+
+class _chassis_response(object):
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+class IDRACChassisSensors(object):
+    def __init__(self, idrac):
+        self.idrac = idrac
+        sensor_resp = self.idrac.invoke_request(method='GET', uri=GET_IDRAC_SENSORS_URI)
+        self.sensors = {member["@odata.id"] for member in sensor_resp.json_data.get("Members", [])}
+    
+    def get_sensor(self, sensor: str):
+        if sensor not in self.sensors:
+            return _chassis_response(404)
+        return self.idrac.invoke_request(method='GET', uri=sensor)

--- a/plugins/module_utils/idrac_utils/info/chassis_sensor_util.py
+++ b/plugins/module_utils/idrac_utils/info/chassis_sensor_util.py
@@ -35,7 +35,7 @@ class IDRACChassisSensors(object):
         self.idrac = idrac
         sensor_resp = self.idrac.invoke_request(method='GET', uri=GET_IDRAC_SENSORS_URI)
         self.sensors = {member["@odata.id"] for member in sensor_resp.json_data.get("Members", [])}
-    
+
     def get_sensor(self, sensor: str):
         if sensor not in self.sensors:
             return _chassis_response(404)

--- a/plugins/module_utils/idrac_utils/info/sensor_amperage.py
+++ b/plugins/module_utils/idrac_utils/info/sensor_amperage.py
@@ -24,15 +24,17 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from .chassis_sensor_util import IDRACChassisSensors
+
 GET_IDRAC_SENSOR_PS1CURRENT1_URI = "/redfish/v1/Chassis/System.Embedded.1/Sensors/PS1Current1"
 GET_IDRAC_SENSOR_PWR_CONSUMPTION_URI = "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardPwrConsumption"
 
 NA = "Not Available"
 
-
 class IDRACSensorAmperageInfo(object):
-    def __init__(self, idrac):
+    def __init__(self, idrac, chassis_sensors: IDRACChassisSensors):
         self.idrac = idrac
+        self.chassis_sensors = chassis_sensors
 
     def map_sensor_amperage_data(self, sensor):
         health_state_map = {
@@ -65,8 +67,8 @@ class IDRACSensorAmperageInfo(object):
     def get_sensor_amperage_info(self):
         """Fetches sensor amperage data from iDRAC and maps it."""
         output = []
-        current_resp = self.idrac.invoke_request(method='GET', uri=GET_IDRAC_SENSOR_PS1CURRENT1_URI)
-        power_resp = self.idrac.invoke_request(method='GET', uri=GET_IDRAC_SENSOR_PWR_CONSUMPTION_URI)
+        current_resp = self.chassis_sensors.get_sensor(GET_IDRAC_SENSOR_PS1CURRENT1_URI)
+        power_resp = self.chassis_sensors.get_sensor(GET_IDRAC_SENSOR_PWR_CONSUMPTION_URI)
 
         if current_resp.status_code == 200 and power_resp.status_code == 200:
             for sensor in [current_resp.json_data, power_resp.json_data]:

--- a/plugins/module_utils/idrac_utils/info/sensor_amperage.py
+++ b/plugins/module_utils/idrac_utils/info/sensor_amperage.py
@@ -31,6 +31,7 @@ GET_IDRAC_SENSOR_PWR_CONSUMPTION_URI = "/redfish/v1/Chassis/System.Embedded.1/Se
 
 NA = "Not Available"
 
+
 class IDRACSensorAmperageInfo(object):
     def __init__(self, idrac, chassis_sensors: IDRACChassisSensors):
         self.idrac = idrac

--- a/plugins/module_utils/idrac_utils/info/system_board_metrics.py
+++ b/plugins/module_utils/idrac_utils/info/system_board_metrics.py
@@ -25,6 +25,8 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+from .chassis_sensor_util import IDRACChassisSensors
+
 GET_SYSTEMBOARD_CPUUSAGE_URI_10 = "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardCPUUsage"
 GET_SYSTEMBOARD_IOUSAGE_URI_10 = "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardIOUsage"
 GET_SYSTEMBOARD_MEMUSAGE_URI_10 = "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardMEMUsage"
@@ -38,11 +40,12 @@ NA = "Not Available"
 
 
 class IDRACSystemBoardMetricsInfo(object):
-    def __init__(self, idrac):
+    def __init__(self, idrac, chassis_sensors: IDRACChassisSensors):
         self.idrac = idrac
+        self.chassis_sensors = chassis_sensors
 
     def get_cpu_usage_details(self):
-        response = self.idrac.invoke_request(method='GET', uri=GET_SYSTEMBOARD_CPUUSAGE_URI_10)
+        response = self.chassis_sensors.get_sensor(GET_SYSTEMBOARD_CPUUSAGE_URI_10)
         if response.status_code == 200:
             cpu_usage_avg_hour = response.json_data.get("Oem", {}).get("Dell", {}).get("AverageReadings", {}).get("LastHour", {}).get("Reading", NA)
             cpu_usage_avg_day = response.json_data.get("Oem", {}).get("Dell", {}).get("AverageReadings", {}).get("LastDay", {}).get("Reading", NA)
@@ -60,10 +63,10 @@ class IDRACSystemBoardMetricsInfo(object):
                 cpu_usage_min_hour, cpu_usage_min_day, cpu_usage_min_week,
                 cpu_usage_peak
             )
-        return {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+        return NA, NA, NA, NA, NA, NA, NA, NA, NA, NA
 
     def get_io_usage_details(self):
-        response = self.idrac.invoke_request(method='GET', uri=GET_SYSTEMBOARD_IOUSAGE_URI_10)
+        response = self.chassis_sensors.get_sensor(GET_SYSTEMBOARD_IOUSAGE_URI_10)
         if response.status_code == 200:
             io_usage_avg_hour = response.json_data.get("Oem", {}).get("Dell", {}).get("AverageReadings", {}).get("LastHour", {}).get("Reading", NA)
             io_usage_avg_day = response.json_data.get("Oem", {}).get("Dell", {}).get("AverageReadings", {}).get("LastDay", {}).get("Reading", NA)
@@ -81,10 +84,10 @@ class IDRACSystemBoardMetricsInfo(object):
                 io_usage_min_hour, io_usage_min_day, io_usage_min_week,
                 io_usage_peak
             )
-        return {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+        return NA, NA, NA, NA, NA, NA, NA, NA, NA, NA
 
     def get_mem_usage_details(self):
-        response = self.idrac.invoke_request(method='GET', uri=GET_SYSTEMBOARD_MEMUSAGE_URI_10)
+        response = self.chassis_sensors.get_sensor(GET_SYSTEMBOARD_MEMUSAGE_URI_10)
         if response.status_code == 200:
             mem_usage_avg_hour = response.json_data.get("Oem", {}).get("Dell", {}).get("AverageReadings", {}).get("LastHour", {}).get("Reading", NA)
             mem_usage_avg_day = response.json_data.get("Oem", {}).get("Dell", {}).get("AverageReadings", {}).get("LastDay", {}).get("Reading", NA)
@@ -102,10 +105,10 @@ class IDRACSystemBoardMetricsInfo(object):
                 mem_usage_min_hour, mem_usage_min_day, mem_usage_min_week,
                 mem_usage_peak
             )
-        return {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+        return NA, NA, NA, NA, NA, NA, NA, NA, NA, NA
 
     def get_sys_usage_details(self):
-        response = self.idrac.invoke_request(method='GET', uri=GET_SYSTEMBOARD_SYSUSAGE_URI_10)
+        response = self.chassis_sensors.get_sensor(GET_SYSTEMBOARD_SYSUSAGE_URI_10)
         if response.status_code == 200:
             sys_usage_avg_hour = response.json_data.get("Oem", {}).get("Dell", {}).get("AverageReadings", {}).get("LastHour", {}).get("Reading", NA)
             sys_usage_avg_day = response.json_data.get("Oem", {}).get("Dell", {}).get("AverageReadings", {}).get("LastDay", {}).get("Reading", NA)
@@ -123,25 +126,25 @@ class IDRACSystemBoardMetricsInfo(object):
                 sys_usage_min_hour, sys_usage_min_day, sys_usage_min_week,
                 sys_usage_peak
             )
-        return {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+        return NA, NA, NA, NA, NA, NA, NA, NA, NA, NA
 
     def get_peak_power_details(self):
-        response = self.idrac.invoke_request(method='GET', uri=GET_SYSTEMBOARD_PWRCONSUMPTION_URI_10)
+        response = self.chassis_sensors.get_sensor(GET_SYSTEMBOARD_PWRCONSUMPTION_URI_10)
         if response.status_code == 200:
             return response.json_data.get("PeakReading", NA)
-        return {}
+        return NA
 
     def get_peak_amperage_details(self):
-        response = self.idrac.invoke_request(method='GET', uri=GET_SYSTEMBOARD_CURRENTCONSUMPTION_URI_10)
+        response = self.chassis_sensors.get_sensor(GET_SYSTEMBOARD_CURRENTCONSUMPTION_URI_10)
         if response.status_code == 200:
             return response.json_data.get("PeakReading", NA)
-        return {}
+        return NA
 
     def get_peak_headroom_details(self):
-        response = self.idrac.invoke_request(method='GET', uri=GET_POWERHEADROOM_URI_10)
+        response = self.chassis_sensors.get_sensor(GET_POWERHEADROOM_URI_10)
         if response.status_code == 200:
             return response.json_data.get("LowestReading", NA)
-        return {}
+        return NA
 
     def get_system_board_metrics_info(self):
         output = []

--- a/plugins/modules/idrac_system_info.py
+++ b/plugins/modules/idrac_system_info.py
@@ -134,6 +134,8 @@ from ansible_collections.dellemc.openmanage.plugins.module_utils.\
     idrac_utils.info.controller_battery import IDRACControllerBatteryInfo
 from ansible_collections.dellemc.openmanage.plugins.module_utils.\
     idrac_utils.info.sensor_amperage import IDRACSensorAmperageInfo
+from ansible_collections.dellemc.openmanage.plugins.module_utils.\
+    idrac_utils.info.chassis_sensor_util import IDRACChassisSensors
 from ansible_collections.dellemc.openmanage.plugins.module_utils.idrac_redfish import iDRACRedfishAPI, IdracAnsibleModule
 from ansible.module_utils.basic import AnsibleModule
 from urllib.error import URLError, HTTPError
@@ -184,6 +186,7 @@ def main():
                 "iDRAC": ""
             }
             if not firmware_obj.is_omsdk_required():
+                chassis_sensors = IDRACChassisSensors(idrac)
                 system_info_dict["BIOS"] = IDRACBiosInfo(idrac).get_bios_system_info()
                 system_info_dict["CPU"] = IDRACCpuInfo(idrac).get_cpu_system_info()
                 system_info_dict["Enclosure"] = IDRACEnclosureInfo(idrac).get_enclosure_system_info()
@@ -191,12 +194,12 @@ def main():
                 system_info_dict["Sensors_Battery"] = IDRACSensorsBatteryInfo(idrac).get_sensors_battery_info()
                 system_info_dict["Sensors_Intrusion"] = IDRACSensorsIntrusionInfo(idrac).get_sensors_intrusion_info()
                 system_info_dict["Sensors_Voltage"] = IDRACSensorsVoltageInfo(idrac).get_sensors_voltage_info()
-                system_info_dict["Sensors_Amperage"] = IDRACSensorAmperageInfo(idrac).get_sensor_amperage_info()
+                system_info_dict["Sensors_Amperage"] = IDRACSensorAmperageInfo(idrac, chassis_sensors).get_sensor_amperage_info()
                 system_info_dict["Sensors_Fan"] = IDRACSensorsFanInfo(idrac).get_sensors_fan_info()
                 system_info_dict["Fan"] = IDRACFanInfo(idrac).get_fan_info()
                 system_info_dict["NIC"] = IDRACNICInfo(idrac).get_nic_info()
                 system_info_dict["System"] = IDRACSystemInfo(idrac).get_system_info()
-                system_info_dict["SystemBoardMetrics"] = IDRACSystemBoardMetricsInfo(idrac).get_system_board_metrics_info()
+                system_info_dict["SystemBoardMetrics"] = IDRACSystemBoardMetricsInfo(idrac, chassis_sensors).get_system_board_metrics_info()
                 system_info_dict["SystemMetrics"] = IDRACSystemMetricsInfo(idrac).get_system_metrics_info()
                 system_info_dict["Video"] = IDRACVideoInfo(idrac).get_idrac_video_details()
                 system_info_dict["Subsystem"] = IDRACSubsystemInfo(idrac).get_subsystem_info()

--- a/tests/integration/targets/idrac_system_info/tests/_validate_sensor_amperage.yml
+++ b/tests/integration/targets/idrac_system_info/tests/_validate_sensor_amperage.yml
@@ -1,4 +1,23 @@
 ---
+- name: Fetch chassis sensors
+  ansible.builtin.uri:
+    url: "{{ chassis_sensors_uri }}"
+    user: "{{ idrac_user }}"
+    password: "{{ idrac_password }}"
+    method: GET
+    force_basic_auth: true
+    validate_certs: false
+    return_content: true
+    status_code: 200
+  register: chassis_sensors_resp
+
+- name: Extract sensors
+  ansible.builtin.set_fact:
+    chassis_sensors: "{{ (chassis_sensors_resp.json.Members
+      | ansible.builtin.rekey_on_member(\"@odata.id\")).keys()
+      | map('regex_replace', '^(.*)$', base_uri + '\\1')
+      | list }}"
+
 - name: Fetch Sensor Amperage details
   ansible.builtin.uri:
     url: "{{ sensor_amperage_uri }}"
@@ -11,6 +30,7 @@
     return_content: true
     status_code: 200
   register: uri_data
+  when: sensor_amperage_uri in chassis_sensors
 
 - name: Structuring Sensor Amperage details
   ansible.builtin.command:

--- a/tests/integration/targets/idrac_system_info/tests/_validate_system_board_metrics.yml
+++ b/tests/integration/targets/idrac_system_info/tests/_validate_system_board_metrics.yml
@@ -1,4 +1,23 @@
 ---
+- name: Fetch chassis sensors
+  ansible.builtin.uri:
+    url: "{{ chassis_sensors_uri }}"
+    user: "{{ idrac_user }}"
+    password: "{{ idrac_password }}"
+    method: GET
+    force_basic_auth: true
+    validate_certs: false
+    return_content: true
+    status_code: 200
+  register: chassis_sensors_resp
+
+- name: Extract sensors
+  ansible.builtin.set_fact:
+    chassis_sensors: "{{ (chassis_sensors_resp.json.Members
+      | ansible.builtin.rekey_on_member(\"@odata.id\")).keys()
+      | map('regex_replace', '^(.*)$', base_uri + '\\1')
+      | list }}"
+
 - name: Fetch system board cpu usage details
   ansible.builtin.uri:
     url: "{{ system_board_cpu_usage_uri }}"
@@ -10,6 +29,7 @@
     return_content: true
     status_code: 200
   register: cpu_usage_uri_details
+  when: system_board_cpu_usage_uri in chassis_sensors
 
 - name: Fetch system board io usage details
   ansible.builtin.uri:
@@ -22,6 +42,7 @@
     return_content: true
     status_code: 200
   register: io_usage_uri_details
+  when: system_board_io_usage_uri in chassis_sensors
 
 - name: Fetch system board mem usage details
   ansible.builtin.uri:
@@ -34,6 +55,7 @@
     return_content: true
     status_code: 200
   register: mem_usage_uri_details
+  when: system_board_mem_usage_uri in chassis_sensors
 
 - name: Fetch system board sys usage details
   ansible.builtin.uri:
@@ -46,6 +68,7 @@
     return_content: true
     status_code: 200
   register: sys_usage_uri_details
+  when: system_board_sys_usage_uri in chassis_sensors
 
 - name: Fetch system board power consumption details
   ansible.builtin.uri:
@@ -58,6 +81,7 @@
     return_content: true
     status_code: 200
   register: power_consumption_uri_details
+  when: system_board_power_consumption_uri in chassis_sensors
 
 - name: Fetch system board current consumption details
   ansible.builtin.uri:
@@ -70,6 +94,7 @@
     return_content: true
     status_code: 200
   register: current_consumption_uri_details
+  when: system_board_current_consumption_uri in chassis_sensors
 
 - name: Fetch system board power headroom details
   ansible.builtin.uri:
@@ -82,18 +107,19 @@
     return_content: true
     status_code: 200
   register: power_headroom_uri_details
+  when: power_headroom_uri in chassis_sensors
 
 - name: Structuring system board metrics uri details
   ansible.builtin.command:
     cmd: >
       python _get_system_board_metrics_details.py
-      '{{ cpu_usage_uri_details.json | to_json }}'
-      '{{ io_usage_uri_details.json | to_json }}'
-      '{{ mem_usage_uri_details.json | to_json }}'
-      '{{ sys_usage_uri_details.json | to_json }}'
-      '{{ power_consumption_uri_details.json | to_json }}'
-      '{{ current_consumption_uri_details.json | to_json }}'
-      '{{ power_headroom_uri_details.json | to_json }}'
+      '{{ cpu_usage_uri_details.json | default({}) | to_json }}'
+      '{{ io_usage_uri_details.json | default({}) | to_json }}'
+      '{{ mem_usage_uri_details.json | default({}) | to_json }}'
+      '{{ sys_usage_uri_details.json | default({}) | to_json }}'
+      '{{ power_consumption_uri_details.json | default({}) | to_json }}'
+      '{{ current_consumption_uri_details.json | default({}) | to_json }}'
+      '{{ power_headroom_uri_details.json | default({}) | to_json }}'
     chdir: "{{ playbook_dir }}/targets/idrac_system_info/tests"
   register: system_board_metrics_uri_details
 

--- a/tests/integration/targets/idrac_system_info/vars/main.yaml
+++ b/tests/integration/targets/idrac_system_info/vars/main.yaml
@@ -55,6 +55,8 @@ subsystem_sensor_voltage_uri: "{{ chassis_uri }}/\
 video_uri: "{{ base_uri }}/{{ redfish_uri }}Systems/System.Embedded.1/"
 thermal_uri: "{{ base_uri }}/{{ redfish_uri }}\
   Chassis/System.Embedded.1/Thermal"
+chassis_sensors_uri: "{{ base_uri }}/{{ redfish_uri }}\
+  Chassis/System.Embedded.1/Sensors"
 system_board_pwrconsumption_uri: "{{ base_uri }}/{{ redfish_uri }}\
   Chassis/System.Embedded.1/Sensors/SystemBoardPwrConsumption"
 system_board_inlettemp_uri: "{{ base_uri }}/{{ redfish_uri }}\

--- a/tests/unit/plugins/module_utils/idrac_utils/test_sensors_amperage.py
+++ b/tests/unit/plugins/module_utils/idrac_utils/test_sensors_amperage.py
@@ -1,9 +1,18 @@
 from ansible_collections.dellemc.openmanage.plugins.module_utils.idrac_utils.info.sensor_amperage import IDRACSensorAmperageInfo
+from ansible_collections.dellemc.openmanage.plugins.module_utils.idrac_utils.info.chassis_sensor_util import IDRACChassisSensors
 from ansible_collections.dellemc.openmanage.tests.unit.plugins.module_utils.idrac_utils.test_idrac_utils import TestUtils
 
 
 class TestIDRACSensorAmperageInfo(TestUtils):
     def test_get_sensor_amperage_info(self, idrac_mock):
+        response = {
+            "Members": [
+                {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/PS1Current1"},
+                {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardPwrConsumption"}
+            ]
+        }
+        idrac_mock.invoke_request.return_value.json_data = response
+        sensors = IDRACChassisSensors(idrac_mock)
         response = {
             "LifetimeReading": 704.729,
             "Status": {
@@ -121,7 +130,7 @@ class TestIDRACSensorAmperageInfo(TestUtils):
             }
         }
         idrac_mock.invoke_request.return_value.json_data = response
-        idrac_sensor_amperage_info = IDRACSensorAmperageInfo(idrac_mock)
+        idrac_sensor_amperage_info = IDRACSensorAmperageInfo(idrac_mock, sensors)
         result = idrac_sensor_amperage_info.get_sensor_amperage_info()
         expected_result = [
             {

--- a/tests/unit/plugins/module_utils/idrac_utils/test_system_board_metrics.py
+++ b/tests/unit/plugins/module_utils/idrac_utils/test_system_board_metrics.py
@@ -12,6 +12,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.dellemc.openmanage.plugins.module_utils.idrac_utils.info.system_board_metrics import IDRACSystemBoardMetricsInfo
+from ansible_collections.dellemc.openmanage.plugins.module_utils.idrac_utils.info.chassis_sensor_util import IDRACChassisSensors
 from ansible_collections.dellemc.openmanage.tests.unit.plugins.module_utils.idrac_utils.test_idrac_utils import TestUtils
 
 NA = "Not Available"
@@ -20,6 +21,7 @@ NA = "Not Available"
 class TestIDRACSystemBoardMetricsInfo(TestUtils):
 
     def test_get_system_metrics_info_success(self, idrac_mock):
+        sensors = self._get_chassis_resp(idrac_mock)
         # Mock responses
         cpu_usage_resp = {
             "Oem": {
@@ -124,7 +126,7 @@ class TestIDRACSystemBoardMetricsInfo(TestUtils):
             headroom_resp
         )
 
-        system_board_metrics_info = IDRACSystemBoardMetricsInfo(idrac_mock)
+        system_board_metrics_info = IDRACSystemBoardMetricsInfo(idrac_mock, sensors)
         result = system_board_metrics_info.get_system_board_metrics_info()
 
         expected = [{
@@ -184,6 +186,7 @@ class TestIDRACSystemBoardMetricsInfo(TestUtils):
         assert result == expected
 
     def test_get_system_metrics_info_missing_fields(self, idrac_mock):
+        sensors = self._get_chassis_resp(idrac_mock)
         # Mock responses with missing fields
         cpu_usage_resp = {
             "Oem": {
@@ -284,7 +287,7 @@ class TestIDRACSystemBoardMetricsInfo(TestUtils):
             headroom_resp
         )
 
-        system_board_metrics_info = IDRACSystemBoardMetricsInfo(idrac_mock)
+        system_board_metrics_info = IDRACSystemBoardMetricsInfo(idrac_mock, sensors)
         result = system_board_metrics_info.get_system_board_metrics_info()
 
         expected = [{
@@ -344,6 +347,7 @@ class TestIDRACSystemBoardMetricsInfo(TestUtils):
         assert result == expected
 
     def test_get_system_metrics_info_non_200_responses(self, idrac_mock):
+        sensors = self._get_chassis_resp(idrac_mock, False)
         # Force non-200 to check fallbacks
         idrac_mock.invoke_request.side_effect = [
             type("Resp", (), {"status_code": 503, "json_data": {}}),
@@ -355,59 +359,59 @@ class TestIDRACSystemBoardMetricsInfo(TestUtils):
             type("Resp", (), {"status_code": 503, "json_data": {}}),
         ]
 
-        system_board_metrics_info = IDRACSystemBoardMetricsInfo(idrac_mock)
+        system_board_metrics_info = IDRACSystemBoardMetricsInfo(idrac_mock, sensors)
         result = system_board_metrics_info.get_system_board_metrics_info()
 
         expected = [{
             "Key": "SystemBoardMetrics",
 
-            "CPUUsageAvg1H": {},
-            "CPUUsageAvg1D": {},
-            "CPUUsageAvg1W": {},
-            "CPUUsageMax1H": {},
-            "CPUUsageMax1D": {},
-            "CPUUsageMax1W": {},
-            "CPUUsageMin1H": {},
-            "CPUUsageMin1D": {},
-            "CPUUsageMin1W": {},
-            "SYSPeakCPUUsage": {},
+            "CPUUsageAvg1H": NA,
+            "CPUUsageAvg1D": NA,
+            "CPUUsageAvg1W": NA,
+            "CPUUsageMax1H": NA,
+            "CPUUsageMax1D": NA,
+            "CPUUsageMax1W": NA,
+            "CPUUsageMin1H": NA,
+            "CPUUsageMin1D": NA,
+            "CPUUsageMin1W": NA,
+            "SYSPeakCPUUsage": NA,
 
-            "IOUsageAvg1H": {},
-            "IOUsageAvg1D": {},
-            "IOUsageAvg1W": {},
-            "IOUsageMax1H": {},
-            "IOUsageMax1D": {},
-            "IOUsageMax1W": {},
-            "IOUsageMin1H": {},
-            "IOUsageMin1D": {},
-            "IOUsageMin1W": {},
-            "SYSPeakIOUsage": {},
+            "IOUsageAvg1H": NA,
+            "IOUsageAvg1D": NA,
+            "IOUsageAvg1W": NA,
+            "IOUsageMax1H": NA,
+            "IOUsageMax1D": NA,
+            "IOUsageMax1W": NA,
+            "IOUsageMin1H": NA,
+            "IOUsageMin1D": NA,
+            "IOUsageMin1W": NA,
+            "SYSPeakIOUsage": NA,
 
-            "MemoryUsageAvg1H": {},
-            "MemoryUsageAvg1D": {},
-            "MemoryUsageAvg1W": {},
-            "MemoryUsageMax1H": {},
-            "MemoryUsageMax1D": {},
-            "MemoryUsageMax1W": {},
-            "MemoryUsageMin1H": {},
-            "MemoryUsageMin1D": {},
-            "MemoryUsageMin1W": {},
-            "SYSPeakMemoryUsage": {},
+            "MemoryUsageAvg1H": NA,
+            "MemoryUsageAvg1D": NA,
+            "MemoryUsageAvg1W": NA,
+            "MemoryUsageMax1H": NA,
+            "MemoryUsageMax1D": NA,
+            "MemoryUsageMax1W": NA,
+            "MemoryUsageMin1H": NA,
+            "MemoryUsageMin1D": NA,
+            "MemoryUsageMin1W": NA,
+            "SYSPeakMemoryUsage": NA,
 
-            "SYSUsageAvg1H": {},
-            "SYSUsageAvg1D": {},
-            "SYSUsageAvg1W": {},
-            "SYSUsageMax1H": {},
-            "SYSUsageMax1D": {},
-            "SYSUsageMax1W": {},
-            "SYSUsageMin1H": {},
-            "SYSUsageMin1D": {},
-            "SYSUsageMin1W": {},
-            "SYSPeakSYSUsage": {},
+            "SYSUsageAvg1H": NA,
+            "SYSUsageAvg1D": NA,
+            "SYSUsageAvg1W": NA,
+            "SYSUsageMax1H": NA,
+            "SYSUsageMax1D": NA,
+            "SYSUsageMax1W": NA,
+            "SYSUsageMin1H": NA,
+            "SYSUsageMin1D": NA,
+            "SYSUsageMin1W": NA,
+            "SYSPeakSYSUsage": NA,
 
-            "PeakPower": {},
-            "PeakAmperage": {},
-            "PeakHeadroom": {},
+            "PeakPower": NA,
+            "PeakAmperage": NA,
+            "PeakHeadroom": NA,
 
             "SystemBoardMetrics": NA
         }]
@@ -424,3 +428,18 @@ class TestIDRACSystemBoardMetricsInfo(TestUtils):
             type("Resp", (), {"status_code": 200, "json_data": amperage_resp}),
             type("Resp", (), {"status_code": 200, "json_data": headroom_resp}),
         ]
+    def _get_chassis_resp(self, idrac_mock, all_members=True):
+        chassis_resp = {
+            "Members": [
+                {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardIOUsage"},
+                {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardMEMUsage"},
+                {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardSYSUsage"},
+                {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardPwrConsumption"},
+                {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardCurrentConsumption"},
+                {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/PowerHeadroom"},
+            ]
+        }
+        if all_members:
+            chassis_resp["Members"].append({"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/SystemBoardCPUUsage"})
+        idrac_mock.invoke_request.return_value.json_data = chassis_resp
+        return IDRACChassisSensors(idrac_mock)

--- a/tests/unit/plugins/module_utils/idrac_utils/test_system_board_metrics.py
+++ b/tests/unit/plugins/module_utils/idrac_utils/test_system_board_metrics.py
@@ -375,6 +375,7 @@ class TestIDRACSystemBoardMetricsInfo(TestUtils):
             type("Resp", (), {"status_code": 200, "json_data": amperage_resp}),
             type("Resp", (), {"status_code": 200, "json_data": headroom_resp}),
         ]
+
     def _get_chassis_resp(self, idrac_mock, all_members=True):
         chassis_resp = {
             "Members": [

--- a/tests/unit/plugins/module_utils/idrac_utils/test_system_board_metrics.py
+++ b/tests/unit/plugins/module_utils/idrac_utils/test_system_board_metrics.py
@@ -19,6 +19,61 @@ NA = "Not Available"
 
 
 class TestIDRACSystemBoardMetricsInfo(TestUtils):
+    all_na = [
+        {
+            "Key": "SystemBoardMetrics",
+
+            "CPUUsageAvg1H": NA,
+            "CPUUsageAvg1D": NA,
+            "CPUUsageAvg1W": NA,
+            "CPUUsageMax1H": NA,
+            "CPUUsageMax1D": NA,
+            "CPUUsageMax1W": NA,
+            "CPUUsageMin1H": NA,
+            "CPUUsageMin1D": NA,
+            "CPUUsageMin1W": NA,
+            "SYSPeakCPUUsage": NA,
+
+            "IOUsageAvg1H": NA,
+            "IOUsageAvg1D": NA,
+            "IOUsageAvg1W": NA,
+            "IOUsageMax1H": NA,
+            "IOUsageMax1D": NA,
+            "IOUsageMax1W": NA,
+            "IOUsageMin1H": NA,
+            "IOUsageMin1D": NA,
+            "IOUsageMin1W": NA,
+            "SYSPeakIOUsage": NA,
+
+            "MemoryUsageAvg1H": NA,
+            "MemoryUsageAvg1D": NA,
+            "MemoryUsageAvg1W": NA,
+            "MemoryUsageMax1H": NA,
+            "MemoryUsageMax1D": NA,
+            "MemoryUsageMax1W": NA,
+            "MemoryUsageMin1H": NA,
+            "MemoryUsageMin1D": NA,
+            "MemoryUsageMin1W": NA,
+            "SYSPeakMemoryUsage": NA,
+
+            "SYSUsageAvg1H": NA,
+            "SYSUsageAvg1D": NA,
+            "SYSUsageAvg1W": NA,
+            "SYSUsageMax1H": NA,
+            "SYSUsageMax1D": NA,
+            "SYSUsageMax1W": NA,
+            "SYSUsageMin1H": NA,
+            "SYSUsageMin1D": NA,
+            "SYSUsageMin1W": NA,
+            "SYSPeakSYSUsage": NA,
+
+            "PeakPower": NA,
+            "PeakAmperage": NA,
+            "PeakHeadroom": NA,
+
+            "SystemBoardMetrics": NA
+        }
+    ]
 
     def test_get_system_metrics_info_success(self, idrac_mock):
         sensors = self._get_chassis_resp(idrac_mock)
@@ -290,61 +345,7 @@ class TestIDRACSystemBoardMetricsInfo(TestUtils):
         system_board_metrics_info = IDRACSystemBoardMetricsInfo(idrac_mock, sensors)
         result = system_board_metrics_info.get_system_board_metrics_info()
 
-        expected = [{
-            "Key": "SystemBoardMetrics",
-
-            "CPUUsageAvg1H": NA,
-            "CPUUsageAvg1D": NA,
-            "CPUUsageAvg1W": NA,
-            "CPUUsageMax1H": NA,
-            "CPUUsageMax1D": NA,
-            "CPUUsageMax1W": NA,
-            "CPUUsageMin1H": NA,
-            "CPUUsageMin1D": NA,
-            "CPUUsageMin1W": NA,
-            "SYSPeakCPUUsage": NA,
-
-            "IOUsageAvg1H": NA,
-            "IOUsageAvg1D": NA,
-            "IOUsageAvg1W": NA,
-            "IOUsageMax1H": NA,
-            "IOUsageMax1D": NA,
-            "IOUsageMax1W": NA,
-            "IOUsageMin1H": NA,
-            "IOUsageMin1D": NA,
-            "IOUsageMin1W": NA,
-            "SYSPeakIOUsage": NA,
-
-            "MemoryUsageAvg1H": NA,
-            "MemoryUsageAvg1D": NA,
-            "MemoryUsageAvg1W": NA,
-            "MemoryUsageMax1H": NA,
-            "MemoryUsageMax1D": NA,
-            "MemoryUsageMax1W": NA,
-            "MemoryUsageMin1H": NA,
-            "MemoryUsageMin1D": NA,
-            "MemoryUsageMin1W": NA,
-            "SYSPeakMemoryUsage": NA,
-
-            "SYSUsageAvg1H": NA,
-            "SYSUsageAvg1D": NA,
-            "SYSUsageAvg1W": NA,
-            "SYSUsageMax1H": NA,
-            "SYSUsageMax1D": NA,
-            "SYSUsageMax1W": NA,
-            "SYSUsageMin1H": NA,
-            "SYSUsageMin1D": NA,
-            "SYSUsageMin1W": NA,
-            "SYSPeakSYSUsage": NA,
-
-            "PeakPower": NA,
-            "PeakAmperage": NA,
-            "PeakHeadroom": NA,
-
-            "SystemBoardMetrics": NA
-        }]
-
-        assert result == expected
+        assert result == self.all_na
 
     def test_get_system_metrics_info_non_200_responses(self, idrac_mock):
         sensors = self._get_chassis_resp(idrac_mock, False)
@@ -362,61 +363,7 @@ class TestIDRACSystemBoardMetricsInfo(TestUtils):
         system_board_metrics_info = IDRACSystemBoardMetricsInfo(idrac_mock, sensors)
         result = system_board_metrics_info.get_system_board_metrics_info()
 
-        expected = [{
-            "Key": "SystemBoardMetrics",
-
-            "CPUUsageAvg1H": NA,
-            "CPUUsageAvg1D": NA,
-            "CPUUsageAvg1W": NA,
-            "CPUUsageMax1H": NA,
-            "CPUUsageMax1D": NA,
-            "CPUUsageMax1W": NA,
-            "CPUUsageMin1H": NA,
-            "CPUUsageMin1D": NA,
-            "CPUUsageMin1W": NA,
-            "SYSPeakCPUUsage": NA,
-
-            "IOUsageAvg1H": NA,
-            "IOUsageAvg1D": NA,
-            "IOUsageAvg1W": NA,
-            "IOUsageMax1H": NA,
-            "IOUsageMax1D": NA,
-            "IOUsageMax1W": NA,
-            "IOUsageMin1H": NA,
-            "IOUsageMin1D": NA,
-            "IOUsageMin1W": NA,
-            "SYSPeakIOUsage": NA,
-
-            "MemoryUsageAvg1H": NA,
-            "MemoryUsageAvg1D": NA,
-            "MemoryUsageAvg1W": NA,
-            "MemoryUsageMax1H": NA,
-            "MemoryUsageMax1D": NA,
-            "MemoryUsageMax1W": NA,
-            "MemoryUsageMin1H": NA,
-            "MemoryUsageMin1D": NA,
-            "MemoryUsageMin1W": NA,
-            "SYSPeakMemoryUsage": NA,
-
-            "SYSUsageAvg1H": NA,
-            "SYSUsageAvg1D": NA,
-            "SYSUsageAvg1W": NA,
-            "SYSUsageMax1H": NA,
-            "SYSUsageMax1D": NA,
-            "SYSUsageMax1W": NA,
-            "SYSUsageMin1H": NA,
-            "SYSUsageMin1D": NA,
-            "SYSUsageMin1W": NA,
-            "SYSPeakSYSUsage": NA,
-
-            "PeakPower": NA,
-            "PeakAmperage": NA,
-            "PeakHeadroom": NA,
-
-            "SystemBoardMetrics": NA
-        }]
-
-        assert result == expected
+        assert result == self.all_na
 
     def _get_sequential_responses(self, cpu_usage_resp, io_usage_resp, mem_usage_resp, sys_usage_resp, power_resp, amperage_resp, headroom_resp):
         return [


### PR DESCRIPTION
# Description
Checking chassis sensor collection before accessing any sensor for system info.

# GitHub Issues

| GitHub Issue # |
| -------------- |
| #1017 |

# ISSUE TYPE
Bugfix Pull Request

# COMPONENT NAME
system_info

# SonarQube
<img width="1364" height="639" alt="image" src="https://github.com/user-attachments/assets/9686878f-9466-49bd-a23f-1a099a73af3b" />

# Tests

## 17G

<img width="1906" height="670" alt="image" src="https://github.com/user-attachments/assets/57a8bb91-3274-48c4-be21-c04266ba47ed" />

## 16G

<img width="1906" height="653" alt="image" src="https://github.com/user-attachments/assets/860eb0b3-2828-4960-9322-a759baa2e6ab" />

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility