### PR TITLE
Use stdlib unittest.mock

### DIFF
--- a/tests/unit/plugins/modules/test_idrac_server_config_profile.py
+++ b/tests/unit/plugins/modules/test_idrac_server_config_profile.py
@@ -13,14 +13,13 @@ __metaclass__ = type
 
 import json
 import pytest
-import mock
 from io import StringIO
 from ansible.module_utils._text import to_text
 from urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import ConnectionError, SSLValidationError
 from ansible_collections.dellemc.openmanage.plugins.modules import idrac_server_config_profile
 from ansible_collections.dellemc.openmanage.tests.unit.plugins.modules.common import FakeAnsibleModule
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 MODULE_UTILS_PATH = 'ansible_collections.dellemc.openmanage.plugins.module_utils.utils.'
@@ -156,7 +155,7 @@ class TestServerConfigProfile(FakeAnsibleModule):
                      "import_buffer": "<SystemConfiguration><Component FQDD='iDRAC.Embedded.1'><Attribute Name='IPMILan.1#Enable'> \
                                        <Value>Disabled</Value></Attribute></Component><Component FQDD='iDRAC.Embedded.1'>"}},
     ])
-    @mock.patch(MODULE_PATH + "idrac_server_config_profile.exists", return_value=True)
+    @patch(MODULE_PATH + "idrac_server_config_profile.exists", return_value=True)
     def test_run_import_scp(self, mock_exists, params, idrac_scp_redfish_mock, idrac_redfish_job_tracking_mock, idrac_default_args, mocker):
         idrac_default_args.update({"command": "import"})
         idrac_default_args.update(params['mparams'])
@@ -198,7 +197,7 @@ class TestServerConfigProfile(FakeAnsibleModule):
                      "import_buffer": "SystemConfiguration><Component FQDD='iDRAC.Embedded.1'><Attribute Name='IPMILan.1#Enable'> \
                      <Value>Disabled</Value></Attribute></Component><Component FQDD='iDRAC.Embedded.1'>"}},
     ])
-    @mock.patch(MODULE_PATH + "idrac_server_config_profile.exists", return_value=True)
+    @patch(MODULE_PATH + "idrac_server_config_profile.exists", return_value=True)
     def test_run_import_scp_gen(self, mock_exists, params, idrac_scp_redfish_mock, idrac_redfish_job_tracking_mock, idrac_default_args, mocker):
         idrac_default_args.update({"command": "import"})
         idrac_default_args.update(params['mparams'])
@@ -233,7 +232,7 @@ class TestServerConfigProfile(FakeAnsibleModule):
                      "import_buffer": "SystemConfiguration><Component FQDD='iDRAC.Embedded.1'><Attribute Name='IPMILan.1#Enable'> \
                      <Value>Disabled</Value></Attribute></Component><Component FQDD='iDRAC.Embedded.1'>"}},
     ])
-    @mock.patch(MODULE_PATH + "idrac_server_config_profile.exists", return_value=True)
+    @patch(MODULE_PATH + "idrac_server_config_profile.exists", return_value=True)
     def test_run_import_scp_gen2222(self, mock_exists, params, idrac_scp_redfish_mock, idrac_redfish_job_tracking_mock, idrac_default_args, mocker):
         idrac_default_args.update({"command": "import"})
         idrac_default_args.update(params['mparams'])


### PR DESCRIPTION
# Description

It is recommended to use unittest.mock from the standard library instead of the mock backport package which shouldn't be necessary with modern Python versions. It especially shouldn't be necessary to import both packages in the same file.

Downstreams like Fedora Linux are planning to remove the standalone mock package from the distribution (https://fedoraproject.org/wiki/Changes/DeprecatePythonMock) for this reason.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME

test

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below

```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility