### PR TITLE
None values handling in powersupply under idrac_system_info

### DIFF
--- a/plugins/module_utils/idrac_utils/info/powersupply.py
+++ b/plugins/module_utils/idrac_utils/info/powersupply.py
@@ -52,9 +52,14 @@ class IDRACPowerSupplyInfo(object):
             get("Dell", {}).get("DellPowerSupplyView", {}).\
             get("RedTypeOfSet")
         if red_type_list:
-            mapped_red_type_list = \
-                [RED_TYPE_MAPPING.get(x) for x in red_type_list]
-            output["RedTypeOfSet"] = ",".join(mapped_red_type_list)
+            mapped_red_type_list = []
+            for x in red_type_list:
+                if x is not None and x in RED_TYPE_MAPPING:
+                    mapped_red_type_list.append(RED_TYPE_MAPPING[x])
+            if len(mapped_red_type_list) > 0:
+                output["RedTypeOfSet"] = ",".join(mapped_red_type_list)
+            else:
+                output["RedTypeOfSet"] = NA
         else:
             output["RedTypeOfSet"] = NA
 

--- a/plugins/module_utils/idrac_utils/info/powersupply.py
+++ b/plugins/module_utils/idrac_utils/info/powersupply.py
@@ -54,8 +54,8 @@ class IDRACPowerSupplyInfo(object):
         if red_type_list:
             mapped_red_type_list = []
             for x in red_type_list:
-                if x is not None and x in RED_TYPE_MAPPING:
-                    mapped_red_type_list.append(RED_TYPE_MAPPING[x])
+                if x is not None:
+                    mapped_red_type_list.append(RED_TYPE_MAPPING.get(x, NA))
             if len(mapped_red_type_list) > 0:
                 output["RedTypeOfSet"] = ",".join(mapped_red_type_list)
             else:

--- a/tests/integration/targets/idrac_system_info/tests/_get_memory_details.py
+++ b/tests/integration/targets/idrac_system_info/tests/_get_memory_details.py
@@ -105,4 +105,4 @@ def get_memory_info_api():
     return memory_output
 
 
-print(get_memory_info_api())
+print(json.dumps(get_memory_info_api()))


### PR DESCRIPTION
# Description
None values are handled in get_red_type_set function in powersupply under idrac_system_info

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
<!---- Docs Pull Request-->
<!---- Feature Pull Request-->
<!---- Test Pull Request-->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
idrac_system_info

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below

```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility