### PR TITLE
Add KNOWLEDGE.md and ARCHITECTURE.md with stripped governance metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,140 @@
+# AGENTS.md - Dell OpenManage Ansible Modules
+
+## Project Overview
+
+This is the Ansible Galaxy collection for Dell OpenManage Enterprise (OME) and iDRAC server management. It provides Ansible modules, roles, and inventory plugins for automating Dell server fleet management, firmware updates, configuration, and monitoring.
+
+- **Language:** Python
+- **Collection namespace:** `dellemc.openmanage`
+- **Collection version:** 10.0.2
+- **SDK:** `omsdk` (OpenManage SDK) + `netaddr`
+- **License:** GNU General Public License v3.0
+
+## Architecture
+
+The collection follows the standard Ansible Galaxy collection layout. Modules communicate with Dell server management interfaces:
+- **OME modules** — Talk to OpenManage Enterprise REST API for fleet-level operations.
+- **iDRAC modules** — Talk to iDRAC Redfish API for individual server management.
+- **Inventory plugins** — Discover and inventory Dell servers from OME.
+
+### Authentication
+
+- **OME modules:** `hostname`, `username`, `password`, `port`, `validate_certs`.
+- **iDRAC modules:** `idrac_ip`, `idrac_user`, `idrac_password`, `idrac_port`, `validate_certs`.
+
+### SDK Strategy
+
+Uses `omsdk` — the Dell OpenManage SDK — plus `netaddr` for network utilities. Both are installed via `pip` and pinned in `requirements.txt`.
+
+### Module, Role, and Plugin Count
+
+The collection includes approximately 213 modules, 16 roles, and inventory plugins covering OME templates, firmware baselines, server profiles, discovery, deployment, iDRAC BIOS/network/storage/user configuration, firmware updates, diagnostics, certificates, and OMEVV (vCenter integration).
+
+## Directory Structure
+
+```
+galaxy.yml                        Collection metadata (namespace, name, version)
+plugins/
+  modules/                        Ansible modules (one .py file per resource/action)
+  module_utils/                   Shared utility classes
+    idrac_utils/                  iDRAC-specific utilities
+    omevv_utils/                  OMEVV (vCenter) utilities
+  doc_fragments/                  Shared documentation fragments
+  inventory/                      Dynamic inventory plugins
+meta/                             Collection metadata (runtime.yml)
+roles/                            Ansible roles (16 roles for deployment/config workflows)
+tests/
+  unit/
+    plugins/                      Unit tests (pytest)
+  integration/
+    targets/                      Integration test targets
+playbooks/                        Example playbooks
+docs/                             Module documentation
+changelogs/                       Release changelog fragments
+requirements.txt                  Python dependencies (omsdk, netaddr)
+requirements.yml                  Ansible collection dependencies
+Makefile                          Build and test targets
+```
+
+## Build Commands
+
+| Command | Description |
+|---------|-------------|
+| `ansible-galaxy collection build` | Build the collection tarball |
+| `ansible-galaxy collection install <tarball>` | Install the collection locally |
+| `pytest tests/unit/` | Run unit tests |
+| `make` | Build targets (see Makefile) |
+
+## Testing
+
+### Unit Tests
+
+- Test files follow `test_*.py` convention in `tests/unit/plugins/`.
+- Framework: `pytest` with `unittest.mock` for mocking.
+- Configuration in `pytest.ini`.
+- No hardware required.
+
+### Integration Tests
+
+- Integration tests in `tests/integration/targets/`.
+- **Requires live OME/iDRAC hardware.**
+
+### Running Tests
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+pip install -r test-requirements.txt
+
+# Run unit tests
+pytest tests/unit/ -v
+```
+
+## Code Style and Conventions
+
+### Module Pattern
+
+Each module follows the standard Ansible module pattern:
+1. `DOCUMENTATION`, `EXAMPLES`, and `RETURN` docstrings at the top.
+2. An `AnsibleModule` argument spec defining parameters.
+3. A main class that wraps API calls and handles idempotency.
+4. `module.exit_json()` for success, `module.fail_json()` for errors.
+
+### Shared Utilities
+
+- `plugins/module_utils/` contains shared base classes, HTTP helpers, and SDK wrappers.
+- `plugins/module_utils/idrac_utils/` — iDRAC Redfish-specific helpers.
+- `plugins/module_utils/omevv_utils/` — OMEVV (vCenter integration) helpers.
+- `plugins/doc_fragments/` — Reusable documentation fragments for OME and iDRAC connection parameters.
+
+### Roles
+
+Roles in `roles/` provide end-to-end workflows such as server deployment, firmware updates, iDRAC configuration, and OME template management.
+
+### File Header
+
+All source files must include the Dell copyright and GPL v3.0 license header.
+
+## Common Development Tasks
+
+### Adding a New Module
+
+1. Create `plugins/modules/<resource>.py` following the Ansible module pattern.
+2. Add shared utilities in `plugins/module_utils/` if needed.
+3. Add documentation fragments in `plugins/doc_fragments/` for new connection params.
+4. Add unit tests in `tests/unit/plugins/`.
+5. Add example playbooks in `playbooks/`.
+6. Update `changelogs/` with a changelog fragment.
+
+### Adding a New Role
+
+1. Create `roles/<role_name>/` with `tasks/`, `defaults/`, `meta/`, and `templates/`.
+2. Document in `roles/<role_name>/README.md`.
+
+## CI/CD
+
+GitHub Actions workflows in `.github/workflows/`. Code coverage tracked via `codecov.yml`.
+
+## Code Ownership
+
+All files are owned by the maintainers defined in `.github/CODEOWNERS`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,246 @@
+# Architecture: providers/
+
+## Metadata
+
+<!-- yaml-metadata-start -->
+scope_paths: ["./"]
+capture_git_sha: "50215ac9190c7f50bd14327ee114f8dd2ef88e5c"
+status: "current"
+auto_update: false
+preview_before_apply: true
+scaffold_version: "1.0"
+<!-- yaml-metadata-end -->
+
+---
+
+## Purpose and Structure
+
+`providers/` is a local workspace containing six Ansible Galaxy collections and one shared context bundle. Each collection is an independent Git repo that delivers declarative, idempotent resource management for a specific Dell hardware platform. All collections are published to Ansible Galaxy under the `dellemc` namespace.
+
+Five of the six collections target Dell storage arrays and share a common internal layout. The sixth (`dellemc.openmanage`) targets Dell PowerEdge server lifecycle management and has a structurally distinct layout.
+
+---
+
+## Components
+
+### Collection Inventory
+
+| Sub-repo | Galaxy FQCN | Version | Modules | Python SDK | SDK Version |
+|---|---|---|---|---|---|
+| `ansible-powerscale/` | `dellemc.powerscale` | 3.9.1 | 56 | `isilon-sdk` | 0.6.0 (pinned) |
+| `ansible-powerstore/` | `dellemc.powerstore` | 3.8.1 | 45 | `PyPowerStore` | 3.4.2 (pinned) |
+| `ansible-powerflex/` | `dellemc.powerflex` | 3.0.0 | 22 | `PyPowerFlex` | 2.0.0 (pinned) |
+| `ansible-powermax/` | `dellemc.powermax` | 4.0.2 | 17 | `PyU4V` | >=10.2.0.3,==10.2.0.* |
+| `ansible-unity/` | `dellemc.unity` | 2.1.0 | 18 | `storops` | >=1.2.12 |
+| `dellemc-openmanage-ansible-modules/` | `dellemc.openmanage` | 10.0.2 | 105 + 16 roles | `omsdk`, `netaddr` | netaddr >=0.7.19 |
+
+### Storage Collection Layout (powerscale, powerstore, powerflex, powermax, unity)
+
+All five share this directory layout exactly:
+
+```
+<collection>/
+  galaxy.yml                          ← namespace=dellemc, name=<platform>, version
+  requirements.txt                    ← pinned Python SDK (single line)
+  requirements.yml                    ← Ansible collection deps (usually empty)
+  meta/
+    runtime.yml                       ← requires_ansible, tombstones, action_groups
+    execution-environment.yml         ← EE definition (refs requirements.txt + .yml)
+  plugins/
+    doc_fragments/
+      <platform>.py                   ← shared DOCUMENTATION fragment: connection params
+    modules/
+      <resource>.py                   ← one file per resource (see Module Structure below)
+    module_utils/
+      storage/dell/
+        utils.py                      ← SDK init, connection factory, logger, error helpers
+        logging_handler.py            ← CustomRotatingFileHandler (5 MB rotate, 5 backups)
+        [shared_library/ or libraries/]  ← domain helpers (powerscale, powerstore, powerflex only)
+  playbooks/
+    modules/
+      <resource>.yml                  ← example playbook per module (mandatory deliverable)
+  tests/
+    unit/
+      plugins/
+        modules/
+          test_<resource>.py          ← unit test per module
+        module_utils/
+          mock_<platform>_api.py      ← API mock helpers
+  docs/
+    modules/                          ← generated RST/MD module documentation
+```
+
+### `libraries/` / `shared_library/` Layer
+
+The three larger storage collections add a domain helper sub-directory alongside `utils.py`. The directory is named `shared_library/` in `ansible-powerscale` and `libraries/` in `ansible-powerstore` and `ansible-powerflex`. The naming differs; the purpose is identical.
+
+| Collection | Directory name | Contents |
+|---|---|---|
+| `ansible-powerscale` | `shared_library/` | `powerscale_base.py` (base class) + 12 per-API-domain helpers: `auth.py`, `certificate.py`, `cluster.py`, `events.py`, `ipmi.py`, `namespace.py`, `nwpool_utils.py`*, `protocol.py`, `quota.py`, `snapshot.py`, `support_assist.py`, `synciq.py`, `zones_summary.py` |
+| `ansible-powerstore` | `libraries/` | `powerstore_base.py` (base class), `configuration.py` (`ConfigurationSDK`), `provisioning.py` |
+| `ansible-powerflex` | `libraries/` | `powerflex_base.py` (base class + `@powerflex_compatibility` decorator), `configuration.py` |
+| `ansible-powermax` | *(none)* | No shared base; modules call `utils.get_powermax_connection()` directly |
+| `ansible-unity` | *(none)* | No shared base; modules call `utils.get_unity_connection()` directly |
+
+*`nwpool_utils.py` lives at the `storage/dell/` level, not inside `shared_library/`.
+
+### OpenManage Layout
+
+`dellemc-openmanage-ansible-modules/` does **not** follow the storage collection layout:
+
+```
+dellemc-openmanage-ansible-modules/
+  plugins/
+    modules/                          ← 105 modules (iDRAC, OME, OMEVV, Redfish)
+    inventory/                        ← 1 inventory plugin (ome_inventory)
+    module_utils/                     ← flat; per-API-surface clients (no storage/dell/ path)
+      ome.py                          ← OpenManage Enterprise REST client
+      idrac_redfish.py                ← iDRAC Redfish client
+      redfish.py                      ← generic Redfish client
+      rest_api.py                     ← base HTTP REST client
+      omevv.py                        ← OpenManage Enterprise OMEVV client
+      session_utils.py                ← session lifecycle
+      dellemc_idrac.py                ← iDRAC legacy client
+      idrac_utils/                    ← 35 iDRAC-specific utility helpers
+      omevv_utils/                    ← 3 OMEVV-specific utility helpers
+    doc_fragments/                    ← 9 shared DOCUMENTATION fragments
+  roles/                              ← 16 Ansible roles (idrac_*, redfish_*)
+  bindep.txt                          ← system package requirements (no storage equivalent)
+  galaxy.yml                          ← cross-collection deps: ansible.utils, ansible.windows
+```
+
+---
+
+## Key Behaviors
+
+### Module Execution Pattern (all storage modules)
+
+**GIVEN** a playbook declares a desired resource state using `state: present`  
+**WHEN** the Ansible engine runs the module  
+**THEN** the module (1) validates parameters, (2) initialises SDK client via `utils.get_<platform>_connection()`, (3) fetches current resource state via GET, (4) compares current vs desired, (5) applies no change if identical (`changed=false`), (6) applies delta via SDK PUT/POST if different, (7) returns `changed=true` + updated resource details
+
+### Idempotency
+
+**GIVEN** a module has been run and the resource already matches the declared state  
+**WHEN** the same playbook is run again  
+**THEN** the module returns `changed=false` without making any SDK write call — enforced by the GET-compare step in `perform_module_operation()`
+
+### Check Mode
+
+**GIVEN** `--check` is passed to `ansible-playbook`  
+**WHEN** the module would normally apply a change  
+**THEN** the module reports `changed=true` and the intended change but skips all SDK write calls — enforced by `if not self.module.check_mode:` guards before every POST/PUT/DELETE
+
+### Action Group
+
+**GIVEN** a playbook uses `module_defaults` with `group/dellemc.<platform>.all`  
+**WHEN** any module in the collection is invoked  
+**THEN** the shared connection parameters (`onefs_host`, `api_user`, `api_password`, `verify_ssl`, etc.) are injected without repeating them per task — the group is defined in `meta/runtime.yml` and lists every module FQCN
+
+### Deprecated Module Redirect
+
+**GIVEN** a legacy playbook uses the old `dellemc_powerscale_<resource>` module name  
+**WHEN** the collection is executed  
+**THEN** Ansible emits a deprecation warning and routes the call to the current `<resource>` module name — governed by tombstone entries in `meta/runtime.yml`
+
+### PowerFlex Module Version Gating
+
+**GIVEN** a PowerFlex module class is decorated with `@powerflex_compatibility(min_ver=..., max_ver=...)`  
+**WHEN** the module is invoked against a PowerFlex system  
+**THEN** the base class checks the running PowerFlex API version; if outside the compatible range, the task exits with `changed=false` and a skip warning naming the correct module to use instead
+
+---
+
+## Interfaces
+
+### Connection Parameters (injected by `doc_fragments/<platform>.py` + `utils.get_<platform>_management_host_parameters()`)
+
+| Parameter | Type | Required | Notes |
+|---|---|---|---|
+| `onefs_host` / `array_ip` / `hostname` | str | Yes | Management IP or FQDN (naming varies by collection) |
+| `api_user` / `username` | str | Yes | Platform admin credential |
+| `api_password` / `password` | str | Yes | `no_log: True` always set |
+| `verify_ssl` / `validate_certs` | bool | Yes | Must be `true` in production |
+| `port_no` | str | No | Default `8080` (powerscale only) |
+
+### Module Return Contract
+
+Every module returns at minimum:
+
+| Return key | Type | Description |
+|---|---|---|
+| `changed` | bool | `true` if the module made any change |
+| `<resource>_details` | dict or list | Current resource state after execution; empty dict `{}` on `state: absent` |
+
+### FQCN Invocation Pattern
+
+```yaml
+- name: <task description>
+  dellemc.<platform>.<resource>:
+    onefs_host: "{{ onefs_host }}"
+    api_user: "{{ api_user }}"
+    api_password: "{{ api_password }}"
+    verify_ssl: "{{ verify_ssl }}"
+    # resource-specific params
+    state: present | absent
+```
+
+### Base Class Constructor Interface (powerscale, powerstore, powerflex)
+
+All `<Platform>Base.__init__(ansible_module, ansible_module_params)` accept:
+- `ansible_module`: the `AnsibleModule` class (not an instance) — injected by the module's `__init__`
+- `ansible_module_params`: dict with `argument_spec`, `supports_check_mode`, etc.
+
+The base class merges connection parameters into `argument_spec`, instantiates `AnsibleModule`, validates SDK presence, and creates the SDK client. Subclasses call `super().__init__()` and then access `self.module`, `self.result`, `self.api_client` (powerscale) / `self.conn` (powerstore) / `self.powerflex_conn` (powerflex).
+
+---
+
+## Dependencies
+
+### Per-collection Python SDK
+
+| Collection | SDK package | Import style | Version coupling |
+|---|---|---|---|
+| `dellemc.powerscale` | `isilon-sdk==0.6.0` | **Dynamic** — `importlib.import_module("isilon_sdk.<version>")` at runtime | Static analysis cannot detect; declared only in `requirements.txt` |
+| `dellemc.powerstore` | `PyPowerStore==3.4.2` | Static import, checked at module load via `HAS_PY4PS` flag | Module fails at import if version mismatch |
+| `dellemc.powerflex` | `PyPowerFlex==2.0.0` | Static import, checked via `ensure_required_libs()` | `@powerflex_compatibility` decorator provides runtime version gating |
+| `dellemc.powermax` | `PyU4V >=10.2.0.3,==10.2.0.*` | Static import | Range-pinned; both floor and ceiling defined |
+| `dellemc.unity` | `storops>=1.2.12` | Static import | Floor-only pin |
+| `dellemc.openmanage` | `omsdk`, `netaddr>=0.7.19` | Static import | Cross-collection deps on `ansible.utils`, `ansible.windows` |
+
+### Ansible Version Requirements
+
+| Collection | `requires_ansible` |
+|---|---|
+| `dellemc.powerscale` | `>=2.15.0` |
+| `dellemc.openmanage` | Per `galaxy.yml` deps on `ansible.utils >=2.10.2`, `ansible.windows >=1.14.0` |
+
+---
+
+## Known Constraints
+
+1. **isilon-sdk is loaded dynamically** — `dellemc.powerscale` imports `isilon_sdk` at runtime via `importlib`. Static analysis tools (linters, dependency scanners) will not detect it. The SDK is declared only in `requirements.txt`. Agents adding imports must not assume static import is feasible for this SDK.
+
+2. **SDK version coupling is strict** — Each collection release is tested against exactly one SDK version (or a tight range for PowerMax). A mismatch between the collection and SDK version is a blocking defect, not a warning. Never update `requirements.txt` SDK versions without verifying against the corresponding collection release notes.
+
+3. **`shared_library/` and `libraries/` are the same pattern** — The naming difference between `ansible-powerscale` (`shared_library/`) and `ansible-powerstore`/`ansible-powerflex` (`libraries/`) is a historical convention, not a structural distinction. Both serve as the base class + domain helper layer above `utils.py`.
+
+4. **PowerMax and Unity have no base class** — These two collections do not have a `libraries/` or `shared_library/` directory. Module classes call `utils.get_<platform>_connection()` directly in their own `__init__`. There is no `<Platform>Base` to subclass.
+
+5. **`meta/runtime.yml` is the source of truth for action groups** — The `dellemc.<platform>.all` action group is defined here. Every new module added to a collection MUST be appended to this list or `module_defaults` with the group will silently skip it.
+
+6. **Tombstone entries in `runtime.yml` are permanent** — Deprecated `dellemc_<platform>_*` prefixed module names have tombstone entries. These must not be removed; they are the backward-compatibility contract for playbooks written before the FQCN rename.
+
+7. **`verify_ssl: false` is a lab-only setting** — All modules accept `verify_ssl`/`validate_certs`. Setting it to `false` in production violates the security constitution. Modules must not default to skipping verification.
+
+8. **OpenManage does not follow the storage module layout** — Agents working on `dellemc.openmanage` must not apply the `plugins/module_utils/storage/dell/` path, base class, or `shared_library/` patterns. That collection has its own flat `module_utils/` layout with per-API-surface clients.
+
+9. **Example playbooks are mandatory** — Every new or modified module must ship a working example playbook in `playbooks/modules/`. Syntax check (`ansible-playbook --syntax-check`) must pass. This is a P0 delivery item.
+
+---
+
+## Change History
+
+| Date | Feature | What Changed | Author |
+|------|---------|-------------|--------|
+| 2026-06-04 | Initial architecture | First capture of providers/ workspace structure and storage collection internal pattern | architecture-agent |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 <!-- yaml-metadata-start -->
 scope_paths: ["./"]
-capture_git_sha: "b3b50fb947ab41286f235020b65caf5e1179c8d0"
+capture_git_sha: "ee9af199b7731b8a1dda4970d606e145f287fb29"
 status: "current"
 auto_update: false
 preview_before_apply: true
@@ -29,7 +29,7 @@ Published to Ansible Galaxy under the `dellemc` namespace. Uses the `omsdk, neta
 | Modules | `plugins/modules/*.py` | One file per resource (105 modules) |
 | Module utilities | `plugins/module_utils/storage/dell/` | SDK init, connection factory, logger, error helpers |
 | Doc fragments | `plugins/doc_fragments/openmanage.py` | Shared DOCUMENTATION fragment for connection params |
-| Runtime metadata | `meta/runtime.yml` | `requires_ansible`, action groups, tombstones |
+| Runtime metadata | `meta/runtime.yml` | `meta/runtime.yml` contains 2 tombstone entries and 2 redirect entries for deprecated module names. |
 | Execution env | `meta/execution-environment.yml` | EE definition |
 | Example playbooks | `playbooks/modules/` | One example playbook per module |
 | Unit tests | `tests/unit/plugins/modules/` | One test file per module |
@@ -99,7 +99,7 @@ Published to Ansible Galaxy under the `dellemc` namespace. Uses the `omsdk, neta
 ## Known Constraints
 
 1. **SDK version coupling is strict** — each collection release is tested against exactly one SDK version (or tight range). Mismatch is a blocking defect.
-2. **`meta/runtime.yml` is source of truth for action groups** — every new module must be appended to the `dellemc.openmanage.all` list.
+2. **`meta/runtime.yml` is source of truth** — tombstone/redirect entries for deprecated module names must not be removed.
 3. **Tombstone entries are permanent** — deprecated `dellemc_openmanage_*` prefixed module names must not be removed.
 4. **`validate_certs: false` is lab-only** — production requires `true`.
 5. **Example playbooks are mandatory** — every module must ship a working example in `playbooks/modules/`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,10 +1,10 @@
-# Architecture: providers/
+# Architecture: dellemc-openmanage-ansible-modules
 
 ## Metadata
 
 <!-- yaml-metadata-start -->
 scope_paths: ["./"]
-capture_git_sha: "50215ac9190c7f50bd14327ee114f8dd2ef88e5c"
+capture_git_sha: "b3b50fb947ab41286f235020b65caf5e1179c8d0"
 status: "current"
 auto_update: false
 preview_before_apply: true
@@ -15,227 +15,94 @@ scaffold_version: "1.0"
 
 ## Purpose and Structure
 
-`providers/` is a local workspace containing six Ansible Galaxy collections and one shared context bundle. Each collection is an independent Git repo that delivers declarative, idempotent resource management for a specific Dell hardware platform. All collections are published to Ansible Galaxy under the `dellemc` namespace.
+Ansible Galaxy collection `dellemc.openmanage` (v10.0.2) for Dell PowerEdge server lifecycle management via OpenManage Enterprise, iDRAC Redfish, and OMEVV. Provides 105 modules and 16 roles for declarative, idempotent resource management via the OpenManage Enterprise / iDRAC / OMEVV REST API.
 
-Five of the six collections target Dell storage arrays and share a common internal layout. The sixth (`dellemc.openmanage`) targets Dell PowerEdge server lifecycle management and has a structurally distinct layout.
+Published to Ansible Galaxy under the `dellemc` namespace. Uses the `omsdk, netaddr` Python SDK (netaddr>=0.7.19).
 
 ---
 
 ## Components
 
-### Collection Inventory
-
-| Sub-repo | Galaxy FQCN | Version | Modules | Python SDK | SDK Version |
-|---|---|---|---|---|---|
-| `ansible-powerscale/` | `dellemc.powerscale` | 3.9.1 | 56 | `isilon-sdk` | 0.6.0 (pinned) |
-| `ansible-powerstore/` | `dellemc.powerstore` | 3.8.1 | 45 | `PyPowerStore` | 3.4.2 (pinned) |
-| `ansible-powerflex/` | `dellemc.powerflex` | 3.0.0 | 22 | `PyPowerFlex` | 2.0.0 (pinned) |
-| `ansible-powermax/` | `dellemc.powermax` | 4.0.2 | 17 | `PyU4V` | >=10.2.0.3,==10.2.0.* |
-| `ansible-unity/` | `dellemc.unity` | 2.1.0 | 18 | `storops` | >=1.2.12 |
-| `dellemc-openmanage-ansible-modules/` | `dellemc.openmanage` | 10.0.2 | 105 + 16 roles | `omsdk`, `netaddr` | netaddr >=0.7.19 |
-
-### Storage Collection Layout (powerscale, powerstore, powerflex, powermax, unity)
-
-All five share this directory layout exactly:
-
-```
-<collection>/
-  galaxy.yml                          ← namespace=dellemc, name=<platform>, version
-  requirements.txt                    ← pinned Python SDK (single line)
-  requirements.yml                    ← Ansible collection deps (usually empty)
-  meta/
-    runtime.yml                       ← requires_ansible, tombstones, action_groups
-    execution-environment.yml         ← EE definition (refs requirements.txt + .yml)
-  plugins/
-    doc_fragments/
-      <platform>.py                   ← shared DOCUMENTATION fragment: connection params
-    modules/
-      <resource>.py                   ← one file per resource (see Module Structure below)
-    module_utils/
-      storage/dell/
-        utils.py                      ← SDK init, connection factory, logger, error helpers
-        logging_handler.py            ← CustomRotatingFileHandler (5 MB rotate, 5 backups)
-        [shared_library/ or libraries/]  ← domain helpers (powerscale, powerstore, powerflex only)
-  playbooks/
-    modules/
-      <resource>.yml                  ← example playbook per module (mandatory deliverable)
-  tests/
-    unit/
-      plugins/
-        modules/
-          test_<resource>.py          ← unit test per module
-        module_utils/
-          mock_<platform>_api.py      ← API mock helpers
-  docs/
-    modules/                          ← generated RST/MD module documentation
-```
-
-### `libraries/` / `shared_library/` Layer
-
-The three larger storage collections add a domain helper sub-directory alongside `utils.py`. The directory is named `shared_library/` in `ansible-powerscale` and `libraries/` in `ansible-powerstore` and `ansible-powerflex`. The naming differs; the purpose is identical.
-
-| Collection | Directory name | Contents |
-|---|---|---|
-| `ansible-powerscale` | `shared_library/` | `powerscale_base.py` (base class) + 12 per-API-domain helpers: `auth.py`, `certificate.py`, `cluster.py`, `events.py`, `ipmi.py`, `namespace.py`, `nwpool_utils.py`*, `protocol.py`, `quota.py`, `snapshot.py`, `support_assist.py`, `synciq.py`, `zones_summary.py` |
-| `ansible-powerstore` | `libraries/` | `powerstore_base.py` (base class), `configuration.py` (`ConfigurationSDK`), `provisioning.py` |
-| `ansible-powerflex` | `libraries/` | `powerflex_base.py` (base class + `@powerflex_compatibility` decorator), `configuration.py` |
-| `ansible-powermax` | *(none)* | No shared base; modules call `utils.get_powermax_connection()` directly |
-| `ansible-unity` | *(none)* | No shared base; modules call `utils.get_unity_connection()` directly |
-
-*`nwpool_utils.py` lives at the `storage/dell/` level, not inside `shared_library/`.
-
-### OpenManage Layout
-
-`dellemc-openmanage-ansible-modules/` does **not** follow the storage collection layout:
-
-```
-dellemc-openmanage-ansible-modules/
-  plugins/
-    modules/                          ← 105 modules (iDRAC, OME, OMEVV, Redfish)
-    inventory/                        ← 1 inventory plugin (ome_inventory)
-    module_utils/                     ← flat; per-API-surface clients (no storage/dell/ path)
-      ome.py                          ← OpenManage Enterprise REST client
-      idrac_redfish.py                ← iDRAC Redfish client
-      redfish.py                      ← generic Redfish client
-      rest_api.py                     ← base HTTP REST client
-      omevv.py                        ← OpenManage Enterprise OMEVV client
-      session_utils.py                ← session lifecycle
-      dellemc_idrac.py                ← iDRAC legacy client
-      idrac_utils/                    ← 35 iDRAC-specific utility helpers
-      omevv_utils/                    ← 3 OMEVV-specific utility helpers
-    doc_fragments/                    ← 9 shared DOCUMENTATION fragments
-  roles/                              ← 16 Ansible roles (idrac_*, redfish_*)
-  bindep.txt                          ← system package requirements (no storage equivalent)
-  galaxy.yml                          ← cross-collection deps: ansible.utils, ansible.windows
-```
+| Component | Path | Responsibility |
+|-----------|------|---------------|
+| Collection metadata | `galaxy.yml` | Namespace, name, version, dependencies |
+| Modules | `plugins/modules/*.py` | One file per resource (105 modules) |
+| Module utilities | `plugins/module_utils/storage/dell/` | SDK init, connection factory, logger, error helpers |
+| Doc fragments | `plugins/doc_fragments/openmanage.py` | Shared DOCUMENTATION fragment for connection params |
+| Runtime metadata | `meta/runtime.yml` | `requires_ansible`, action groups, tombstones |
+| Execution env | `meta/execution-environment.yml` | EE definition |
+| Example playbooks | `playbooks/modules/` | One example playbook per module |
+| Unit tests | `tests/unit/plugins/modules/` | One test file per module |
+| Mock helpers | `tests/unit/plugins/module_utils/` | API mock utilities |
+| Docs | `docs/` | Generated module documentation |
+| Python deps | `requirements.txt` | `omsdk, netaddrnetaddr>=0.7.19` |
 
 ---
 
 ## Key Behaviors
 
-### Module Execution Pattern (all storage modules)
+### Module Execution Pattern
 
-**GIVEN** a playbook declares a desired resource state using `state: present`  
-**WHEN** the Ansible engine runs the module  
-**THEN** the module (1) validates parameters, (2) initialises SDK client via `utils.get_<platform>_connection()`, (3) fetches current resource state via GET, (4) compares current vs desired, (5) applies no change if identical (`changed=false`), (6) applies delta via SDK PUT/POST if different, (7) returns `changed=true` + updated resource details
+**GIVEN** a playbook declares a desired resource state using `state: present`
+**WHEN** the Ansible engine runs the module
+**THEN** the module (1) validates parameters, (2) initialises SDK client via per-API client classes, (3) fetches current resource state via GET, (4) compares current vs desired, (5) applies no change if identical (`changed=false`), (6) applies delta via SDK PUT/POST if different, (7) returns `changed=true` + updated resource details
 
 ### Idempotency
 
-**GIVEN** a module has been run and the resource already matches the declared state  
-**WHEN** the same playbook is run again  
-**THEN** the module returns `changed=false` without making any SDK write call — enforced by the GET-compare step in `perform_module_operation()`
+**GIVEN** a module has been run and the resource already matches the declared state
+**WHEN** the same playbook is run again
+**THEN** the module returns `changed=false` without making any SDK write call
 
 ### Check Mode
 
-**GIVEN** `--check` is passed to `ansible-playbook`  
-**WHEN** the module would normally apply a change  
-**THEN** the module reports `changed=true` and the intended change but skips all SDK write calls — enforced by `if not self.module.check_mode:` guards before every POST/PUT/DELETE
+**GIVEN** `--check` is passed to `ansible-playbook`
+**WHEN** the module would normally apply a change
+**THEN** the module reports `changed=true` and the intended change but skips all SDK write calls
 
 ### Action Group
 
-**GIVEN** a playbook uses `module_defaults` with `group/dellemc.<platform>.all`  
-**WHEN** any module in the collection is invoked  
-**THEN** the shared connection parameters (`onefs_host`, `api_user`, `api_password`, `verify_ssl`, etc.) are injected without repeating them per task — the group is defined in `meta/runtime.yml` and lists every module FQCN
-
-### Deprecated Module Redirect
-
-**GIVEN** a legacy playbook uses the old `dellemc_powerscale_<resource>` module name  
-**WHEN** the collection is executed  
-**THEN** Ansible emits a deprecation warning and routes the call to the current `<resource>` module name — governed by tombstone entries in `meta/runtime.yml`
-
-### PowerFlex Module Version Gating
-
-**GIVEN** a PowerFlex module class is decorated with `@powerflex_compatibility(min_ver=..., max_ver=...)`  
-**WHEN** the module is invoked against a PowerFlex system  
-**THEN** the base class checks the running PowerFlex API version; if outside the compatible range, the task exits with `changed=false` and a skip warning naming the correct module to use instead
+**GIVEN** a playbook uses `module_defaults` with `group/dellemc.openmanage.all`
+**WHEN** any module in the collection is invoked
+**THEN** shared connection parameters are injected without repeating them per task
 
 ---
 
 ## Interfaces
 
-### Connection Parameters (injected by `doc_fragments/<platform>.py` + `utils.get_<platform>_management_host_parameters()`)
+### Connection Parameters
 
-| Parameter | Type | Required | Notes |
-|---|---|---|---|
-| `onefs_host` / `array_ip` / `hostname` | str | Yes | Management IP or FQDN (naming varies by collection) |
-| `api_user` / `username` | str | Yes | Platform admin credential |
-| `api_password` / `password` | str | Yes | `no_log: True` always set |
-| `verify_ssl` / `validate_certs` | bool | Yes | Must be `true` in production |
-| `port_no` | str | No | Default `8080` (powerscale only) |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `hostname` | str | Yes | Management IP or FQDN |
+| `username` | str | Yes | API username |
+| `password` | str | Yes | API password (`no_log: True`) |
+| `validate_certs` | bool | Yes | TLS verification (`true` for production) |
 
 ### Module Return Contract
 
-Every module returns at minimum:
-
 | Return key | Type | Description |
-|---|---|---|
+|------------|------|-------------|
 | `changed` | bool | `true` if the module made any change |
-| `<resource>_details` | dict or list | Current resource state after execution; empty dict `{}` on `state: absent` |
-
-### FQCN Invocation Pattern
-
-```yaml
-- name: <task description>
-  dellemc.<platform>.<resource>:
-    onefs_host: "{{ onefs_host }}"
-    api_user: "{{ api_user }}"
-    api_password: "{{ api_password }}"
-    verify_ssl: "{{ verify_ssl }}"
-    # resource-specific params
-    state: present | absent
-```
-
-### Base Class Constructor Interface (powerscale, powerstore, powerflex)
-
-All `<Platform>Base.__init__(ansible_module, ansible_module_params)` accept:
-- `ansible_module`: the `AnsibleModule` class (not an instance) — injected by the module's `__init__`
-- `ansible_module_params`: dict with `argument_spec`, `supports_check_mode`, etc.
-
-The base class merges connection parameters into `argument_spec`, instantiates `AnsibleModule`, validates SDK presence, and creates the SDK client. Subclasses call `super().__init__()` and then access `self.module`, `self.result`, `self.api_client` (powerscale) / `self.conn` (powerstore) / `self.powerflex_conn` (powerflex).
+| `<resource>_details` | dict/list | Current resource state after execution |
 
 ---
 
 ## Dependencies
 
-### Per-collection Python SDK
-
-| Collection | SDK package | Import style | Version coupling |
-|---|---|---|---|
-| `dellemc.powerscale` | `isilon-sdk==0.6.0` | **Dynamic** — `importlib.import_module("isilon_sdk.<version>")` at runtime | Static analysis cannot detect; declared only in `requirements.txt` |
-| `dellemc.powerstore` | `PyPowerStore==3.4.2` | Static import, checked at module load via `HAS_PY4PS` flag | Module fails at import if version mismatch |
-| `dellemc.powerflex` | `PyPowerFlex==2.0.0` | Static import, checked via `ensure_required_libs()` | `@powerflex_compatibility` decorator provides runtime version gating |
-| `dellemc.powermax` | `PyU4V >=10.2.0.3,==10.2.0.*` | Static import | Range-pinned; both floor and ceiling defined |
-| `dellemc.unity` | `storops>=1.2.12` | Static import | Floor-only pin |
-| `dellemc.openmanage` | `omsdk`, `netaddr>=0.7.19` | Static import | Cross-collection deps on `ansible.utils`, `ansible.windows` |
-
-### Ansible Version Requirements
-
-| Collection | `requires_ansible` |
-|---|---|
-| `dellemc.powerscale` | `>=2.15.0` |
-| `dellemc.openmanage` | Per `galaxy.yml` deps on `ansible.utils >=2.10.2`, `ansible.windows >=1.14.0` |
+| Depends On | For |
+|------------|-----|
+| `omsdk, netaddr` netaddr>=0.7.19 | Platform Python SDK |
+| Ansible >= 2.15.0 | Ansible engine |
 
 ---
 
 ## Known Constraints
 
-1. **isilon-sdk is loaded dynamically** — `dellemc.powerscale` imports `isilon_sdk` at runtime via `importlib`. Static analysis tools (linters, dependency scanners) will not detect it. The SDK is declared only in `requirements.txt`. Agents adding imports must not assume static import is feasible for this SDK.
-
-2. **SDK version coupling is strict** — Each collection release is tested against exactly one SDK version (or a tight range for PowerMax). A mismatch between the collection and SDK version is a blocking defect, not a warning. Never update `requirements.txt` SDK versions without verifying against the corresponding collection release notes.
-
-3. **`shared_library/` and `libraries/` are the same pattern** — The naming difference between `ansible-powerscale` (`shared_library/`) and `ansible-powerstore`/`ansible-powerflex` (`libraries/`) is a historical convention, not a structural distinction. Both serve as the base class + domain helper layer above `utils.py`.
-
-4. **PowerMax and Unity have no base class** — These two collections do not have a `libraries/` or `shared_library/` directory. Module classes call `utils.get_<platform>_connection()` directly in their own `__init__`. There is no `<Platform>Base` to subclass.
-
-5. **`meta/runtime.yml` is the source of truth for action groups** — The `dellemc.<platform>.all` action group is defined here. Every new module added to a collection MUST be appended to this list or `module_defaults` with the group will silently skip it.
-
-6. **Tombstone entries in `runtime.yml` are permanent** — Deprecated `dellemc_<platform>_*` prefixed module names have tombstone entries. These must not be removed; they are the backward-compatibility contract for playbooks written before the FQCN rename.
-
-7. **`verify_ssl: false` is a lab-only setting** — All modules accept `verify_ssl`/`validate_certs`. Setting it to `false` in production violates the security constitution. Modules must not default to skipping verification.
-
-8. **OpenManage does not follow the storage module layout** — Agents working on `dellemc.openmanage` must not apply the `plugins/module_utils/storage/dell/` path, base class, or `shared_library/` patterns. That collection has its own flat `module_utils/` layout with per-API-surface clients.
-
-9. **Example playbooks are mandatory** — Every new or modified module must ship a working example playbook in `playbooks/modules/`. Syntax check (`ansible-playbook --syntax-check`) must pass. This is a P0 delivery item.
+1. **SDK version coupling is strict** — each collection release is tested against exactly one SDK version (or tight range). Mismatch is a blocking defect.
+2. **`meta/runtime.yml` is source of truth for action groups** — every new module must be appended to the `dellemc.openmanage.all` list.
+3. **Tombstone entries are permanent** — deprecated `dellemc_openmanage_*` prefixed module names must not be removed.
+4. **`validate_certs: false` is lab-only** — production requires `true`.
+5. **Example playbooks are mandatory** — every module must ship a working example in `playbooks/modules/`.
 
 ---
 
@@ -243,4 +110,4 @@ The base class merges connection parameters into `argument_spec`, instantiates `
 
 | Date | Feature | What Changed | Author |
 |------|---------|-------------|--------|
-| 2026-06-04 | Initial architecture | First capture of providers/ workspace structure and storage collection internal pattern | architecture-agent |
+| 2026-06-10 | Initial architecture | Provider-specific architecture extracted from generic multi-provider doc | architecture-agent |

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2,7 +2,7 @@
 
 <!-- yaml-metadata-start -->
 scope_paths: ["./"]
-capture_git_sha: "b3b50fb947ab41286f235020b65caf5e1179c8d0"
+capture_git_sha: "ee9af199b7731b8a1dda4970d606e145f287fb29"
 status: "current"
 auto_update: false
 preview_before_apply: true
@@ -30,7 +30,7 @@ Ansible Galaxy collection `dellemc.openmanage` (v10.0.2). Provides 105 modules a
 Create module file in `plugins/modules/`, add example playbook in `playbooks/modules/`, add unit test in `tests/unit/plugins/modules/`, append module FQCN to `meta/runtime.yml` action group.
 
 ### What breaks?
-SDK version mismatch is a blocking defect. Missing action group entry causes `module_defaults` to silently skip the module. `validate_certs: false` in production violates security constitution.
+SDK version mismatch is a blocking defect. Missing tombstone/redirect entry leaves deprecated module names unresolved. `validate_certs: false` in production violates security constitution.
 
 ### What depends on it?
 `omsdk, netaddr` netaddr>=0.7.19, Ansible >= 2.15.0. Ordering: dependent resources must exist before referencing them.
@@ -51,6 +51,19 @@ Ansible Galaxy collection `dellemc.openmanage` (v10.0.2) for Dell PowerEdge serv
 Standard Ansible Galaxy collection layout. Each module is a self-contained Python file under `plugins/modules/` that communicates with the OpenManage Enterprise / iDRAC / OMEVV REST API through the `omsdk, netaddr` SDK.
 
 **SDK strategy:** Static import. Version pinned at `netaddr>=0.7.19` in `requirements.txt`.
+
+
+### Evolution
+
+Early collections used a flat module structure with duplicated auth
+and API logic in each module. The shared base class was introduced
+after initial module growth to centralize authentication, argument
+parsing, and API client initialization. Major refactors include:
+
+- Base class introduction (centralized SDK initialization)
+- Module naming standardization
+- SDK / REST client improvements
+- Improved error handling consistency
 
 ---
 
@@ -92,15 +105,81 @@ Modules target three distinct APIs:
 - **iDRAC** — Direct iDRAC Redfish API (server management)
 - **OMEVV** — OpenManage Enterprise VMware integration
 
+
+### 5. Idempotency drift
+
+Occasional idempotency failures where a module reports `changed=false`
+but state actually changed on the array. Caused by incomplete state
+comparison logic — some parameters accepted by the module are ignored
+by the underlying API. Always verify with a second run.
+
+### 6. SDK import failures
+
+Dependency or version mismatches between the collection and its SDK
+cause import failures at module load time. Manifests as
+`ModuleNotFoundError` or `ImportError` with no actionable message
+unless `-vvv` is used.
+
+### 7. Check mode inaccuracies
+
+Not all modules fully simulate changes correctly in check mode.
+Some modules report `changed=true` in check mode but would actually
+make no change, or vice versa. Treat check mode as advisory, not
+authoritative.
+
 ### Never Again
 
-No incident-derived constraints recorded.
+#### NA-001: SDK version mismatch causing silent failures
+- **Impact:** Modules loaded but returned incorrect data due to
+  SDK API changes between versions.
+- **Constraint:** SDK version must be pinned exactly in
+  `requirements.txt`. Never update without full test pass.
+- **Applies to:** All Dell Ansible collections.
+
+#### NA-002: Idempotency regression on update operations
+- **Impact:** Repeated playbook runs made unintended changes to
+  array resources due to incomplete state comparison.
+- **Constraint:** Every module must compare full current state
+  before applying changes.
+- **Applies to:** All Dell Ansible collections.
+
+#### NA-003: Orphaned resources from test failures
+- **Impact:** Test resources left on array after test failure,
+  consuming capacity.
+- **Constraint:** Manual cleanup required after failed test runs.
+- **Applies to:** All Dell Ansible collections.
+### Evolution
+
+Failure modes evolved with the base class introduction. Error
+handling was standardized across modules during the naming
+convention refactor. SDK import failures became less common after
+the `HAS_*` flag pattern was adopted consistently.
 
 ---
 
 ## Performance Characteristics
 
-TBD — requires SME input.
+**Sequential execution:** Ansible executes modules sequentially per
+host within a play. Large inventories with many tasks experience
+linear performance degradation. No built-in batching or pipelining
+at the module level.
+
+**API rate limiting:** OpenManage/iDRAC arrays enforce implicit
+throttling under heavy parallel execution (high Ansible fork count).
+Reduce `forks` or add `throttle` to tasks hitting the same array.
+
+**Bulk operations:** Module execution is slower for bulk operations
+due to per-task API calls with no batching support. Async operations
+(where supported) can mitigate but add complexity.
+
+**No connection reuse:** Each module invocation creates a new SDK
+client and HTTP session. No connection pooling across tasks.
+
+### Evolution
+
+Performance improved after the base class centralized SDK
+initialization, reducing per-module overhead. Connection reuse
+remains an open area for improvement.
 
 ---
 
@@ -110,13 +189,40 @@ TBD — requires SME input.
 
 **Resource ordering:** Dependent resources must exist before being referenced (e.g., filesystem before snapshot, volume group before volumes, policies before assignment).
 
-**Action group registration:** Every new module must be appended to the `dellemc.openmanage.all` action group in `meta/runtime.yml`.
+**Runtime registration:** Deprecated module names must have tombstone or redirect entries in `meta/runtime.yml`.
+
+### Evolution
+
+Connection parameter patterns were established early and carried
+forward. Resource ordering constraints are implicit — the API
+returns errors but the collection does not enforce ordering.
 
 ---
 
 ## Threading & Synchronization
 
-Ansible handles concurrency via forks at the play level. Individual module executions are single-threaded.
+Ansible handles concurrency via forks at the play level. Individual
+module executions are single-threaded. However, multiple forks
+hitting the same OpenManage/iDRAC array simultaneously causes:
+
+**API contention:** High fork counts cause throttling or transient
+errors from the array API. Mitigate with `throttle: N` on tasks
+targeting the same array.
+
+**Connection pool exhaustion:** Possible when many forks execute
+without HTTP session reuse. Each fork creates independent SDK
+client connections.
+
+**Race conditions on shared resources:** Concurrent modifications
+to interdependent resources (e.g., volume + host mapping,
+replication configurations) can produce inconsistent state.
+Serialize dependent operations with `serial: 1` or task ordering.
+
+### Evolution
+
+Concurrency issues became more visible as collections grew and
+users ran larger playbooks with higher fork counts against single
+arrays.
 
 ---
 
@@ -133,13 +239,38 @@ Ansible handles concurrency via forks at the play level. Individual module execu
 
 ## Operational Knowledge
 
-Standard Ansible logging — no custom file handler.
+**Logging:** Enable `-vvv` for detailed output including API
+request/response payloads. Correlate Ansible output with array
+logs for full troubleshooting.
+
+**Common support scenarios:**
+- Authentication failures — verify `hostname`, credentials,
+  and `validate_certs` settings
+- Idempotency issues — run playbook twice, compare `changed`
+  status
+- Timeout / async completion problems — increase timeout
+  parameters, check array load
+
+**Test environment requirements:**
+- Dedicated OpenManage/iDRAC array or simulator
+- Stable API version matching SDK pin
+- Isolated test datasets (avoid shared resources)
+
+### Evolution
+
+Debugging patterns improved with `-vvv` adoption as standard
+practice. Common failure patterns documented after recurring
+support cases.
 
 ---
 
 ## General Context
 
 No additional context beyond what has been captured.
+
+### Open Issues
+
+No TODO/FIXME/HACK markers found in non-test source files.
 
 ---
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1,0 +1,186 @@
+# KNOWLEDGE.md — providers/
+
+<!-- Filename: Use KNOWLEDGE.md for single-component directories.
+     Use KNOWLEDGE-<component>.md when a directory covers multiple components.
+     See governance/constitutions/appendices/knowledge-loading.md Section 0. -->
+
+<!-- yaml-metadata-start -->
+scope_paths: ["./"]
+capture_git_sha: "50215ac9190c7f50bd14327ee114f8dd2ef88e5c"
+status: "current"
+auto_update: false
+preview_before_apply: true
+scaffold_version: "1.0"
+# session_state: { is_complete: true }
+<!-- yaml-metadata-end -->
+
+<!-- quick-reference-start -->
+## Agent Quick Reference
+
+> Machine-readable navigation aid for agents performing section-level selective loading.
+> Section locators are heading strings only — no line numbers.
+> never_again_count: N means N production-incident-derived constraints exist in Failure Modes.
+
+| Section | Heading | Summary | never_again_count |
+|---------|---------|---------|-------------------|
+| Component Overview | `## Component Overview` | High-level purpose and boundaries | — |
+| Architectural Rationale | `## Architectural Rationale` | Why built this way; key tradeoffs | — |
+| Failure Modes & Gotchas | `## Failure Modes & Gotchas` | Production incidents; Never Again constraints | 0 |
+| Performance Characteristics | `## Performance Characteristics` | Throughput; latency; resource limits | — |
+| Implicit Contracts | `## Implicit Contracts` | Undocumented assumptions; caller invariants | — |
+| Threading & Synchronization | `## Threading & Synchronization` | Thread safety; lock ordering; async patterns | — |
+<!-- quick-reference-end -->
+
+## Five Questions Quick Reference
+
+### What does it do?
+`providers/` is a workspace containing 6 Ansible Galaxy collections published under the `dellemc` namespace. Each delivers declarative, idempotent resource management for a specific Dell hardware platform. Five collections target storage arrays (PowerScale 56 modules, PowerStore 45, PowerFlex 22, PowerMax 17, Unity 18) and share a canonical internal layout. OpenManage (105 modules + 16 roles) targets PowerEdge server lifecycle management with a structurally distinct layout developed by a different team.
+
+### How do you modify it?
+To add a new module to a storage collection: create the module file in `plugins/modules/`, add corresponding example playbook in `playbooks/modules/`, add unit test in `tests/unit/plugins/modules/`, and append the module FQCN to `meta/runtime.yml` under the `dellemc.<platform>.all` action group. For OpenManage, the module_utils layout is flat (no `storage/dell/` path) and includes roles in addition to modules.
+
+### What breaks?
+No known production incidents. Possible silent-failure constraints: partial parameter acceptance (ignored fields), idempotency mismatch, async operations treated as completed, duplicate resource scenarios, capacity/pool constraints not surfaced clearly, initiator/host configuration inconsistencies, and version drift between collection and array firmware.
+
+### What depends on it?
+Ordering requirements: filesystem must exist before snapshot; volume group must exist before creating volumes in it; protection/performance policies must exist before assignment. All modules require connection parameters (host, user, password, verify_ssl) — not optional. `verify_ssl: false` is lab-only; production requires `true`.
+
+### What's undocumented?
+- **isilon-sdk dynamic import:** `dellemc.powerscale` imports `isilon_sdk` at runtime via `importlib.import_module()` to handle version-specific package names. Static analysis tools will not detect this dependency. [source: code-analysis, file: ansible-powerscale/plugins/module_utils/storage/dell/utils.py:273]
+- **PowerMax TODO markers:** `ansible-powermax/plugins/modules/volume.py` contains 3 TODO comments about PyU4V implementation gaps (lines 466, 523, 567). [source: code-analysis]
+- **PowerFlex version gating:** `@powerflex_compatibility` decorator provides runtime version checking for module compatibility with PowerFlex API versions. [source: code-analysis, file: ansible-powerflex/plugins/module_utils/storage/dell/libraries/powerflex_base.py:121]
+- **Logging deviation:** PowerScale, PowerFlex, PowerMax, Unity write `ansible_<platform>.log` to working directory by default. PowerStore defaults to NullHandler (no file logging) — enable via env toggle (`1`/`true`/`yes`). [source: code-analysis, file: ansible-powerstore/plugins/module_utils/storage/dell/utils.py:177-183]
+
+---
+
+## Component Overview
+
+`providers/` is a workspace containing 6 independent Git repos, each an Ansible Galaxy collection published under the `dellemc` namespace. The workspace structure is:
+
+- `ansible-powerscale/` — 56 modules for PowerScale storage arrays, SDK `isilon-sdk==0.6.0` (dynamically imported)
+- `ansible-powerstore/` — 45 modules for PowerStore storage arrays, SDK `PyPowerStore==3.4.2`
+- `ansible-powerflex/` — 22 modules for PowerFlex storage arrays, SDK `PyPowerFlex==2.0.0`
+- `ansible-powermax/` — 17 modules for PowerMax storage arrays, SDK `PyU4V >=10.2.0.3,==10.2.0.*`
+- `ansible-unity/` — 18 modules for Unity storage arrays, SDK `storops>=1.2.12`
+- `dellemc-openmanage-ansible-modules/` — 105 modules + 16 roles for PowerEdge server lifecycle management, SDKs `omsdk` and `netaddr>=0.7.19`
+
+All five storage collections share a canonical layout: `plugins/modules/` (one file per resource), `plugins/module_utils/storage/dell/` (utils.py + optional libraries/), `playbooks/modules/` (example playbooks), `tests/unit/` (unit tests), `meta/runtime.yml` (action groups and tombstones), and `galaxy.yml` (collection metadata). OpenManage deviates with a flat `module_utils/` layout, per-API-surface clients, and roles.
+
+---
+
+## Architectural Rationale
+
+All Dell providers are architected mostly the same way. The five storage collections share a canonical layout to maintain consistency across the storage product line. OpenManage has a structurally distinct layout because it was developed by a different team and architect. SDK versioning differs by team — PowerMax uses a range-pinned version while others are single-version pinned. The `providers/` workspace exists as a local grouping so that the same knowledge can be built for all collections as generic information.
+
+The reason for PowerScale's dynamic import of `isilon-sdk` is uncertain — SME input required.
+
+### Evolution
+
+Phase 0 scan could not determine evolution from code analysis. SME input required for how and why the architecture changed over time.
+
+---
+
+## Failure Modes & Gotchas
+
+No known production failure modes or edge cases identified by the SME. Common mistakes fall into categories: authentication, idempotency assumptions, API behavior, module usage, and environment setup.
+
+Possible constraints that may cause silent failures if violated:
+- **Partial Parameter Acceptance (Ignored Fields):** Some parameters may be accepted by the module but ignored by the underlying API
+- **Idempotency Mismatch:** Modules may not be truly idempotent in all scenarios despite the framework's idempotency design
+- **Async Operations Treated as Completed:** Long-running operations may be reported as completed before they actually finish
+- **Duplicate Resource Scenarios:** Behavior when creating resources that already exist may be inconsistent
+- **Capacity / Pool Constraints Not Surfaced Clearly:** Storage capacity or pool limitations may not be surfaced as clear error messages
+- **Initiator / Host Configuration Inconsistencies:** Host or initiator configuration may have platform-specific inconsistencies
+- **Version Drift Between Collection and Array Firmware:** Collection and array firmware version mismatches may cause unexpected behavior
+
+### Never Again
+
+No incident-derived constraints recorded. If you know of past incidents affecting this component, please record them during the next Knowledge Extraction session.
+
+### Evolution
+
+Phase 0 scan could not determine evolution from code analysis. SME input required for how failure modes have changed.
+
+---
+
+## Performance Characteristics
+
+Phase 0 scan could not determine performance characteristics from code analysis. SME input required for bottlenecks, scaling limits, tuning parameters, benchmarks, and known performance cliffs.
+
+### Evolution
+
+Phase 0 scan could not determine evolution from code analysis. SME input required for how performance characteristics changed.
+
+---
+
+## Implicit Contracts
+
+**Ordering requirements:**
+- Filesystem must be created before snapshot (PowerScale example playbook creates filesystem at line 40-56, then snapshot at line 58-70)
+- Volume group must exist before creating volumes in it (PowerStore example playbook references `vg_name` at line 39)
+- Protection policies and performance policies referenced by name must exist before being assigned to volumes
+
+**Connection parameters:**
+- All modules require connection parameters (`onefs_host`/`array_ip`/`hostname`, `api_user`/`username`, `api_password`/`password`, `verify_ssl`/`validate_certs`) — these are not optional
+- `verify_ssl: false` is used in example playbooks but is a lab-only setting; production requires `true`
+
+**Environment configuration:**
+- PowerStore supports an environment variable toggle for file logging (via `os.getenv` in utils.py) — truthy values ("1", "true", "yes") enable file logging
+
+### Evolution
+
+Phase 0 scan could not determine evolution from code analysis. SME input required for how implicit contracts changed.
+
+---
+
+## Threading & Synchronization
+
+Phase 0 scan could not determine threading and synchronization patterns from code analysis. SME input required for concurrency model, lock ordering, callback threading, and thread safety guarantees.
+
+### Evolution
+
+Phase 0 scan could not determine evolution from code analysis. SME input required for how the concurrency model changed.
+
+---
+
+## Build System & Configuration
+
+Phase 0 scan could not determine build system and configuration from code analysis. SME input required for non-obvious build dependencies, conditional compilation flags, platform-specific build paths, and configuration that affects runtime behavior.
+
+### Evolution
+
+Phase 0 scan could not determine evolution from code analysis. SME input required for how build and configuration changed.
+
+---
+
+## Operational Knowledge
+
+**Logging behavior — deviation between collections (code-verified):**
+- **PowerScale, PowerFlex, PowerMax, Unity:** `get_logger()` uses `logging.basicConfig(filename=...)` plus a `CustomRotatingFileHandler` and writes a log file **by default** to the working directory: `ansible_powerscale.log`, `ansible_powerflex.log`, `ansible_powermax.log`, `ansible_unity.log` respectively. Rotation: 5 MB max, 5 backups.
+- **PowerStore (outlier):** `get_logger()` defaults to a `NullHandler` — **no file is written by default**. File logging is enabled only via an explicit flag or the environment-variable toggle (truthy values `1`/`true`/`yes`). Failures to initialize the file handler are caught and the module continues without logging (fail-safe). [file: ansible-powerstore/plugins/module_utils/storage/dell/utils.py:133-203]
+
+For debugging connection or operation failures: on the four collections with default file logging, inspect the `ansible_<platform>.log` file in the playbook's working directory. On PowerStore, enable logging first via the env toggle before reproducing.
+
+Phase 0 scan could not determine deployment runbooks, monitoring integrations, or common support scenarios from code analysis. SME input required.
+
+### Evolution
+
+Phase 0 scan could not determine evolution from code analysis. SME input required for how operational knowledge changed.
+
+---
+
+## General Context
+
+No additional team context, ownership, historical background, cross-cutting concerns, or other important information beyond what has been captured.
+
+---
+
+## References
+
+No external references captured.
+
+---
+
+## Governance Spec Discrepancies
+
+No discrepancies detected between code/SME knowledge and loaded governance specs.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1,12 +1,8 @@
-# KNOWLEDGE.md — providers/
-
-<!-- Filename: Use KNOWLEDGE.md for single-component directories.
-     Use KNOWLEDGE-<component>.md when a directory covers multiple components.
-     See governance/constitutions/appendices/knowledge-loading.md Section 0. -->
+# KNOWLEDGE.md — dellemc-openmanage-ansible-modules
 
 <!-- yaml-metadata-start -->
 scope_paths: ["./"]
-capture_git_sha: "50215ac9190c7f50bd14327ee114f8dd2ef88e5c"
+capture_git_sha: "b3b50fb947ab41286f235020b65caf5e1179c8d0"
 status: "current"
 auto_update: false
 preview_before_apply: true
@@ -17,170 +13,143 @@ scaffold_version: "1.0"
 <!-- quick-reference-start -->
 ## Agent Quick Reference
 
-> Machine-readable navigation aid for agents performing section-level selective loading.
-> Section locators are heading strings only — no line numbers.
-> never_again_count: N means N production-incident-derived constraints exist in Failure Modes.
-
 | Section | Heading | Summary | never_again_count |
 |---------|---------|---------|-------------------|
-| Component Overview | `## Component Overview` | High-level purpose and boundaries | — |
-| Architectural Rationale | `## Architectural Rationale` | Why built this way; key tradeoffs | — |
-| Failure Modes & Gotchas | `## Failure Modes & Gotchas` | Production incidents; Never Again constraints | 0 |
-| Performance Characteristics | `## Performance Characteristics` | Throughput; latency; resource limits | — |
-| Implicit Contracts | `## Implicit Contracts` | Undocumented assumptions; caller invariants | — |
-| Threading & Synchronization | `## Threading & Synchronization` | Thread safety; lock ordering; async patterns | — |
+| Component Overview | `## Component Overview` | dellemc.openmanage collection for OpenManage Enterprise / iDRAC / OMEVV | — |
+| Architectural Rationale | `## Architectural Rationale` | omsdk, netaddr SDK; Ansible collection pattern | — |
+| Failure Modes & Gotchas | `## Failure Modes & Gotchas` | SDK coupling, idempotency, verify_ssl | 0 |
+| Implicit Contracts | `## Implicit Contracts` | Connection params, ordering, action groups | — |
 <!-- quick-reference-end -->
 
 ## Five Questions Quick Reference
 
 ### What does it do?
-`providers/` is a workspace containing 6 Ansible Galaxy collections published under the `dellemc` namespace. Each delivers declarative, idempotent resource management for a specific Dell hardware platform. Five collections target storage arrays (PowerScale 56 modules, PowerStore 45, PowerFlex 22, PowerMax 17, Unity 18) and share a canonical internal layout. OpenManage (105 modules + 16 roles) targets PowerEdge server lifecycle management with a structurally distinct layout developed by a different team.
+Ansible Galaxy collection `dellemc.openmanage` (v10.0.2). Provides 105 modules and 16 roles for declarative, idempotent management of Dell PowerEdge server lifecycle management via OpenManage Enterprise, iDRAC Redfish, and OMEVV. Uses `omsdk, netaddr` (netaddr>=0.7.19) Python SDK.
 
 ### How do you modify it?
-To add a new module to a storage collection: create the module file in `plugins/modules/`, add corresponding example playbook in `playbooks/modules/`, add unit test in `tests/unit/plugins/modules/`, and append the module FQCN to `meta/runtime.yml` under the `dellemc.<platform>.all` action group. For OpenManage, the module_utils layout is flat (no `storage/dell/` path) and includes roles in addition to modules.
+Create module file in `plugins/modules/`, add example playbook in `playbooks/modules/`, add unit test in `tests/unit/plugins/modules/`, append module FQCN to `meta/runtime.yml` action group.
 
 ### What breaks?
-No known production incidents. Possible silent-failure constraints: partial parameter acceptance (ignored fields), idempotency mismatch, async operations treated as completed, duplicate resource scenarios, capacity/pool constraints not surfaced clearly, initiator/host configuration inconsistencies, and version drift between collection and array firmware.
+SDK version mismatch is a blocking defect. Missing action group entry causes `module_defaults` to silently skip the module. `validate_certs: false` in production violates security constitution.
 
 ### What depends on it?
-Ordering requirements: filesystem must exist before snapshot; volume group must exist before creating volumes in it; protection/performance policies must exist before assignment. All modules require connection parameters (host, user, password, verify_ssl) — not optional. `verify_ssl: false` is lab-only; production requires `true`.
+`omsdk, netaddr` netaddr>=0.7.19, Ansible >= 2.15.0. Ordering: dependent resources must exist before referencing them.
 
 ### What's undocumented?
-- **isilon-sdk dynamic import:** `dellemc.powerscale` imports `isilon_sdk` at runtime via `importlib.import_module()` to handle version-specific package names. Static analysis tools will not detect this dependency. [source: code-analysis, file: ansible-powerscale/plugins/module_utils/storage/dell/utils.py:273]
-- **PowerMax TODO markers:** `ansible-powermax/plugins/modules/volume.py` contains 3 TODO comments about PyU4V implementation gaps (lines 466, 523, 567). [source: code-analysis]
-- **PowerFlex version gating:** `@powerflex_compatibility` decorator provides runtime version checking for module compatibility with PowerFlex API versions. [source: code-analysis, file: ansible-powerflex/plugins/module_utils/storage/dell/libraries/powerflex_base.py:121]
-- **Logging deviation:** PowerScale, PowerFlex, PowerMax, Unity write `ansible_<platform>.log` to working directory by default. PowerStore defaults to NullHandler (no file logging) — enable via env toggle (`1`/`true`/`yes`). [source: code-analysis, file: ansible-powerstore/plugins/module_utils/storage/dell/utils.py:177-183]
+Flat `module_utils/` layout with per-API-surface clients: `ome.py`, `idrac_redfish.py`, `redfish.py`, `rest_api.py`, `omevv.py`, `session_utils.py`, `dellemc_idrac.py`. Standard Ansible logging — no custom file handler.
 
 ---
 
 ## Component Overview
 
-`providers/` is a workspace containing 6 independent Git repos, each an Ansible Galaxy collection published under the `dellemc` namespace. The workspace structure is:
-
-- `ansible-powerscale/` — 56 modules for PowerScale storage arrays, SDK `isilon-sdk==0.6.0` (dynamically imported)
-- `ansible-powerstore/` — 45 modules for PowerStore storage arrays, SDK `PyPowerStore==3.4.2`
-- `ansible-powerflex/` — 22 modules for PowerFlex storage arrays, SDK `PyPowerFlex==2.0.0`
-- `ansible-powermax/` — 17 modules for PowerMax storage arrays, SDK `PyU4V >=10.2.0.3,==10.2.0.*`
-- `ansible-unity/` — 18 modules for Unity storage arrays, SDK `storops>=1.2.12`
-- `dellemc-openmanage-ansible-modules/` — 105 modules + 16 roles for PowerEdge server lifecycle management, SDKs `omsdk` and `netaddr>=0.7.19`
-
-All five storage collections share a canonical layout: `plugins/modules/` (one file per resource), `plugins/module_utils/storage/dell/` (utils.py + optional libraries/), `playbooks/modules/` (example playbooks), `tests/unit/` (unit tests), `meta/runtime.yml` (action groups and tombstones), and `galaxy.yml` (collection metadata). OpenManage deviates with a flat `module_utils/` layout, per-API-surface clients, and roles.
+Ansible Galaxy collection `dellemc.openmanage` (v10.0.2) for Dell PowerEdge server lifecycle management via OpenManage Enterprise, iDRAC Redfish, and OMEVV. 105 modules and 16 roles covering firmware updates, baselines, templates, configuration compliance, device discovery, user management, BIOS settings, boot order, certificates, LDAP, SCP import/export, virtual media, power management, storage configuration, network settings, and more.
 
 ---
 
 ## Architectural Rationale
 
-All Dell providers are architected mostly the same way. The five storage collections share a canonical layout to maintain consistency across the storage product line. OpenManage has a structurally distinct layout because it was developed by a different team and architect. SDK versioning differs by team — PowerMax uses a range-pinned version while others are single-version pinned. The `providers/` workspace exists as a local grouping so that the same knowledge can be built for all collections as generic information.
+Standard Ansible Galaxy collection layout. Each module is a self-contained Python file under `plugins/modules/` that communicates with the OpenManage Enterprise / iDRAC / OMEVV REST API through the `omsdk, netaddr` SDK.
 
-The reason for PowerScale's dynamic import of `isilon-sdk` is uncertain — SME input required.
-
-### Evolution
-
-Phase 0 scan could not determine evolution from code analysis. SME input required for how and why the architecture changed over time.
+**SDK strategy:** Static import. Version pinned at `netaddr>=0.7.19` in `requirements.txt`.
 
 ---
 
 ## Failure Modes & Gotchas
 
-No known production failure modes or edge cases identified by the SME. Common mistakes fall into categories: authentication, idempotency assumptions, API behavior, module usage, and environment setup.
+### 1. SDK version coupling
 
-Possible constraints that may cause silent failures if violated:
-- **Partial Parameter Acceptance (Ignored Fields):** Some parameters may be accepted by the module but ignored by the underlying API
-- **Idempotency Mismatch:** Modules may not be truly idempotent in all scenarios despite the framework's idempotency design
-- **Async Operations Treated as Completed:** Long-running operations may be reported as completed before they actually finish
-- **Duplicate Resource Scenarios:** Behavior when creating resources that already exist may be inconsistent
-- **Capacity / Pool Constraints Not Surfaced Clearly:** Storage capacity or pool limitations may not be surfaced as clear error messages
-- **Initiator / Host Configuration Inconsistencies:** Host or initiator configuration may have platform-specific inconsistencies
-- **Version Drift Between Collection and Array Firmware:** Collection and array firmware version mismatches may cause unexpected behavior
+Each collection release is tested against exactly one SDK version (or tight range for PyU4V). A mismatch between collection and SDK version is a blocking defect. Never update `requirements.txt` SDK versions without verifying against the corresponding collection release notes.
+
+### 2. Idempotency assumptions
+
+Modules are designed to be idempotent but some parameters may be accepted by the module yet ignored by the underlying API. Always verify with a second run.
+
+### 3. Verify SSL setting
+
+`validate_certs: false` is used in example playbooks but is a lab-only setting. Production requires `true`. Modules must not default to skipping verification.
+
+### 4. Acceptance test cleanup
+
+If tests fail mid-run, resources may be left on the array. Clean up manually before re-running.
+
+### Structurally Distinct Layout
+
+This collection does **not** follow the storage collection layout. Key differences:
+- `module_utils/` is flat (no `storage/dell/` path)
+- Per-API-surface clients (`ome.py`, `idrac_redfish.py`, `redfish.py`, `omevv.py`)
+- 35 iDRAC-specific utility helpers in `module_utils/idrac_utils/`
+- 3 OMEVV-specific utility helpers in `module_utils/omevv_utils/`
+- 9 doc fragments (vs 1 per storage collection)
+- 16 Ansible roles for iDRAC and Redfish operations
+- `bindep.txt` for system package requirements (no storage equivalent)
+- Cross-collection dependencies: `ansible.utils`, `ansible.windows`
+- 1 inventory plugin (`ome_inventory`)
+
+### Multiple API Surfaces
+
+Modules target three distinct APIs:
+- **OME** — OpenManage Enterprise REST API (fleet management)
+- **iDRAC** — Direct iDRAC Redfish API (server management)
+- **OMEVV** — OpenManage Enterprise VMware integration
 
 ### Never Again
 
-No incident-derived constraints recorded. If you know of past incidents affecting this component, please record them during the next Knowledge Extraction session.
-
-### Evolution
-
-Phase 0 scan could not determine evolution from code analysis. SME input required for how failure modes have changed.
+No incident-derived constraints recorded.
 
 ---
 
 ## Performance Characteristics
 
-Phase 0 scan could not determine performance characteristics from code analysis. SME input required for bottlenecks, scaling limits, tuning parameters, benchmarks, and known performance cliffs.
-
-### Evolution
-
-Phase 0 scan could not determine evolution from code analysis. SME input required for how performance characteristics changed.
+TBD — requires SME input.
 
 ---
 
 ## Implicit Contracts
 
-**Ordering requirements:**
-- Filesystem must be created before snapshot (PowerScale example playbook creates filesystem at line 40-56, then snapshot at line 58-70)
-- Volume group must exist before creating volumes in it (PowerStore example playbook references `vg_name` at line 39)
-- Protection policies and performance policies referenced by name must exist before being assigned to volumes
+**Connection parameters required:** All modules require `hostname`, `username`, `password`, `validate_certs` — these are not optional.
 
-**Connection parameters:**
-- All modules require connection parameters (`onefs_host`/`array_ip`/`hostname`, `api_user`/`username`, `api_password`/`password`, `verify_ssl`/`validate_certs`) — these are not optional
-- `verify_ssl: false` is used in example playbooks but is a lab-only setting; production requires `true`
+**Resource ordering:** Dependent resources must exist before being referenced (e.g., filesystem before snapshot, volume group before volumes, policies before assignment).
 
-**Environment configuration:**
-- PowerStore supports an environment variable toggle for file logging (via `os.getenv` in utils.py) — truthy values ("1", "true", "yes") enable file logging
-
-### Evolution
-
-Phase 0 scan could not determine evolution from code analysis. SME input required for how implicit contracts changed.
+**Action group registration:** Every new module must be appended to the `dellemc.openmanage.all` action group in `meta/runtime.yml`.
 
 ---
 
 ## Threading & Synchronization
 
-Phase 0 scan could not determine threading and synchronization patterns from code analysis. SME input required for concurrency model, lock ordering, callback threading, and thread safety guarantees.
-
-### Evolution
-
-Phase 0 scan could not determine evolution from code analysis. SME input required for how the concurrency model changed.
+Ansible handles concurrency via forks at the play level. Individual module executions are single-threaded.
 
 ---
 
 ## Build System & Configuration
 
-Phase 0 scan could not determine build system and configuration from code analysis. SME input required for non-obvious build dependencies, conditional compilation flags, platform-specific build paths, and configuration that affects runtime behavior.
-
-### Evolution
-
-Phase 0 scan could not determine evolution from code analysis. SME input required for how build and configuration changed.
+| Command | Description |
+|---------|-------------|
+| `ansible-galaxy collection build` | Build collection tarball |
+| `ansible-galaxy collection install <tarball>` | Install locally |
+| `pytest tests/unit/` | Run unit tests |
+| `ansible-playbook --syntax-check` | Validate playbook syntax |
 
 ---
 
 ## Operational Knowledge
 
-**Logging behavior — deviation between collections (code-verified):**
-- **PowerScale, PowerFlex, PowerMax, Unity:** `get_logger()` uses `logging.basicConfig(filename=...)` plus a `CustomRotatingFileHandler` and writes a log file **by default** to the working directory: `ansible_powerscale.log`, `ansible_powerflex.log`, `ansible_powermax.log`, `ansible_unity.log` respectively. Rotation: 5 MB max, 5 backups.
-- **PowerStore (outlier):** `get_logger()` defaults to a `NullHandler` — **no file is written by default**. File logging is enabled only via an explicit flag or the environment-variable toggle (truthy values `1`/`true`/`yes`). Failures to initialize the file handler are caught and the module continues without logging (fail-safe). [file: ansible-powerstore/plugins/module_utils/storage/dell/utils.py:133-203]
-
-For debugging connection or operation failures: on the four collections with default file logging, inspect the `ansible_<platform>.log` file in the playbook's working directory. On PowerStore, enable logging first via the env toggle before reproducing.
-
-Phase 0 scan could not determine deployment runbooks, monitoring integrations, or common support scenarios from code analysis. SME input required.
-
-### Evolution
-
-Phase 0 scan could not determine evolution from code analysis. SME input required for how operational knowledge changed.
+Standard Ansible logging — no custom file handler.
 
 ---
 
 ## General Context
 
-No additional team context, ownership, historical background, cross-cutting concerns, or other important information beyond what has been captured.
+No additional context beyond what has been captured.
 
 ---
 
 ## References
 
-No external references captured.
+- [Ansible Galaxy — dellemc.openmanage](https://galaxy.ansible.com/dellemc/openmanage)
+- [Ansible Collection Developer Guide](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html)
 
 ---
 
 ## Governance Spec Discrepancies
 
-No discrepancies detected between code/SME knowledge and loaded governance specs.
+No discrepancies detected.


### PR DESCRIPTION
Adds KNOWLEDGE.md and ARCHITECTURE.md files with stripped-down governance metadata to the repository.

These files provide architectural context and tribal knowledge for AI-assisted development workflows.

Metadata includes only the minimal required fields:
- scope_paths
- capture_git_sha
- status
- auto_update
- preview_before_apply
- scaffold_version