### PR TITLE
Fix wrong parameter name in redfish_storage_volume

### DIFF
--- a/plugins/modules/redfish_storage_volume.py
+++ b/plugins/modules/redfish_storage_volume.py
@@ -149,7 +149,7 @@ options:
   reboot_server:
     description:
       - Reboot the server to apply the changes.
-      - I(reboot_server) is applicable only when I(apply_timeout) is C(OnReset) or when the default value for the apply time of the controller is C(OnReset).
+      - I(reboot_server) is applicable only when I(apply_time) is C(OnReset) or when the default value for the apply time of the controller is C(OnReset).
     type: bool
     default: false
     version_added: 8.5.0

--- a/roles/redfish_storage_volume/README.md
+++ b/roles/redfish_storage_volume/README.md
@@ -273,7 +273,7 @@ Only applicable when I(state) is C(present).</td>
     <td></td>
     <td>bool</td>
     <td>- Reboot the server to apply the changes.</br>
-- I(reboot_server) is applicable only when I(apply_timeout) is C(OnReset) or when the default value for the apply time of the controller is C(OnReset).</td>
+- I(reboot_server) is applicable only when I(apply_time) is C(OnReset) or when the default value for the apply time of the controller is C(OnReset).</td>
   </tr>
   <tr>
     <td>force_reboot</td>

--- a/roles/redfish_storage_volume/meta/argument_specs.yml
+++ b/roles/redfish_storage_volume/meta/argument_specs.yml
@@ -162,7 +162,7 @@ argument_specs:
       reboot_server:
         description:
           - Reboot the server to apply the changes.
-          - I(reboot_server) is applicable only when I(apply_timeout) is C(OnReset) or
+          - I(reboot_server) is applicable only when I(apply_time) is C(OnReset) or
             when the default value for the apply time of the controller is C(OnReset).
         type: bool
         default: false

--- a/tests/integration/targets/idrac_redfish_storage_volume/files/ansible_doc.txt
+++ b/tests/integration/targets/idrac_redfish_storage_volume/files/ansible_doc.txt
@@ -173,7 +173,7 @@
 - ''
 - '- reboot_server'
 - '        Reboot the server to apply the changes.'
-- '        `reboot_server'' is applicable only when `apply_timeout'' is'
+- '        `reboot_server'' is applicable only when `apply_time'' is'
 - '        `OnReset'' or when the default value for the apply time of the'
 - '        controller is `OnReset''.'
 - '        default: false'


### PR DESCRIPTION
# Description
Fixes documentation in ``redfish_storage_volume`` to use the right parameter name ``apply_time`` instead of ``apply_timeout``.

# ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
redfish_storage_volume

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility