### PR TITLE
[ECS02C-1196] Fix operator precedence bug in OpenURLResponse.success property

### DIFF
--- a/plugins/module_utils/idrac_redfish.py
+++ b/plugins/module_utils/idrac_redfish.py
@@ -92,7 +92,7 @@ class OpenURLResponse(object):
     @property
     def success(self):
         status = self.status_code
-        return status >= 200 & status <= 299
+        return 200 <= status <= 299
 
     @property
     def headers(self):

--- a/plugins/module_utils/redfish.py
+++ b/plugins/module_utils/redfish.py
@@ -77,7 +77,7 @@ class OpenURLResponse(object):
     @property
     def success(self):
         status = self.status_code
-        return status >= 200 & status <= 299
+        return 200 <= status <= 299
 
     @property
     def headers(self):

--- a/plugins/module_utils/rest_api.py
+++ b/plugins/module_utils/rest_api.py
@@ -78,7 +78,7 @@ class OpenURLResponse(object):
     @property
     def success(self):
         status = self.status_code
-        return status >= 200 & status <= 299
+        return 200 <= status <= 299
 
     @property
     def token_header(self):

--- a/plugins/module_utils/session_utils.py
+++ b/plugins/module_utils/session_utils.py
@@ -95,7 +95,7 @@ class OpenURLResponse():
         :rtype: bool
         """
         status = self.status_code
-        return status >= 200 & status <= 299
+        return 200 <= status <= 299
 
     @property
     def headers(self):


### PR DESCRIPTION
## Summary

Fixes ECS02C-1196 — the `success` property in four `OpenURLResponse` classes used a buggy expression with bitwise AND, causing all HTTP status codes >= 200 to be incorrectly treated as success.

## Root Cause

The expression `status >= 200 & status <= 299` was parsed as `status >= (200 & status) <= 299` due to Python operator precedence (`&` binds tighter than `>=`/`<=`).

## Changed

- `plugins/module_utils/rest_api.py`
- `plugins/module_utils/session_utils.py`
- `plugins/module_utils/idrac_redfish.py`
- `plugins/module_utils/redfish.py`

All changed from `status >= 200 & status <= 299` to `200 <= status <= 299`.

## Validation

- Syntax check passed
- Unit tests: 97 passed in 1.05s
- Logic verification: 2xx → True, 3xx/4xx/5xx → False

## Breaking Changes

None. This corrects the intended behavior.