### PR TITLE
[ECS02C-1197] Fix insecure validate_certs default in iDRACRedfishAPI

### DIFF
--- a/plugins/module_utils/idrac_redfish.py
+++ b/plugins/module_utils/idrac_redfish.py
@@ -148,7 +148,7 @@ class iDRACRedfishAPI(object):
         self.password = module_params['idrac_password']
         self.x_auth_token = module_params.get('x_auth_token')
         self.port = module_params['idrac_port']
-        self.validate_certs = module_params.get("validate_certs", False)
+        self.validate_certs = module_params.get("validate_certs", True)
         self.ca_path = module_params.get("ca_path")
         self.timeout = module_params.get("timeout", 30)
         self.use_proxy = module_params.get("use_proxy", True)


### PR DESCRIPTION
## Summary

Fixes ECS02C-1197 — the `validate_certs` parameter in `iDRACRedfishAPI.__init__` had an insecure fallback default of `False`, which disables TLS certificate verification when the class is instantiated directly without an explicit `validate_certs` parameter.

## Root Cause

Line 151 used `module_params.get("validate_certs", False)` while `IdracAnsibleModule` (line 536) correctly defaults to `True`. This inconsistency exposed direct instantiations of `iDRACRedfishAPI` to man-in-the-middle attacks.

## Changed

- `plugins/module_utils/idrac_redfish.py:151`

Changed from `module_params.get("validate_certs", False)` to `module_params.get("validate_certs", True)`.

## Validation

- Syntax check passed
- Unit tests: 49 passed in 0.17s

## Breaking Changes

None for users who explicitly set `validate_certs`. Users who relied on the insecure default (not passing `validate_certs` and expecting no TLS verification) will now need to explicitly set `validate_certs=False` — this is the intended secure-by-default behavior.