### PR TITLE
[ECS02C-1198] Fix insecure validate_certs default in iDRACConnection

### DIFF
--- a/plugins/module_utils/dellemc_idrac.py
+++ b/plugins/module_utils/dellemc_idrac.py
@@ -65,7 +65,7 @@ class iDRACConnection:
             raise ValueError("hostname, username and password required")
         self.handle = None
         self.creds = UserCredentials(self.idrac_user, self.idrac_pwd)
-        self.validate_certs = module_params.get("validate_certs", False)
+        self.validate_certs = module_params.get("validate_certs", True)
         self.ca_path = module_params.get("ca_path")
         verify_ssl = False
         if self.validate_certs is True:


### PR DESCRIPTION
## Summary

Fixes ECS02C-1198 — the `validate_certs` parameter in `iDRACConnection.__init__` had an insecure fallback default of `False`, which set `WsManOptions.verify_ssl` to `False` when `iDRACConnection` is instantiated without an explicit `validate_certs` parameter.

## Root Cause

Line 68 used `module_params.get("validate_certs", False)`. When `validate_certs` is not provided, `WsManOptions` is created with `verify_ssl=False`, disabling SSL/TLS certificate verification and exposing connections to man-in-the-middle attacks.

## Changed

- `plugins/module_utils/dellemc_idrac.py:68`

Changed from `module_params.get("validate_certs", False)` to `module_params.get("validate_certs", True)`.

## Validation

- Syntax check passed
- Verified `iDRACConnection` now defaults `validate_certs` to `True` and `WsManOptions.verify_ssl` to `True`
- Live OMSDK/WSMAN test was attempted on iDRAC `100.68.135.10`, but WSMAN is not enabled on that target, so a full live OMSDK module test could not be completed

## Breaking Changes

This is a security fix that changes the default from insecure to secure. Users who previously relied on the implicit `validate_certs=False` (not passing the parameter) will now need to explicitly set `validate_certs=False` or provide a proper `ca_path`.