### PR TITLE
[ECS02C-1199] Fix insecure validate_certs default in SessionAPI

### DIFF
--- a/plugins/module_utils/session_utils.py
+++ b/plugins/module_utils/session_utils.py
@@ -133,7 +133,7 @@ class SessionAPI():
                 - "password" (str): The password for authentication.
                 - "port" (int, optional): The port number. Defaults to None.
                 - "validate_certs" (bool, optional): Whether to validate SSL certificates. Defaults
-                to False.
+                to True.
                 - "ca_path" (str, optional): The path to the CA certificate file. Defaults to None.
                 - "timeout" (int, optional): The timeout value in seconds. Defaults to None.
                 - "use_proxy" (bool, optional): Whether to use a proxy. Defaults to True.
@@ -145,7 +145,7 @@ class SessionAPI():
         self.username = module_params.get("username")
         self.password = module_params.get("password")
         self.port = module_params.get("port")
-        self.validate_certs = module_params.get("validate_certs", False)
+        self.validate_certs = module_params.get("validate_certs", True)
         self.ca_path = module_params.get("ca_path")
         self.timeout = module_params.get("timeout")
         self.use_proxy = module_params.get("use_proxy", True)


### PR DESCRIPTION
## Summary

Fixes ECS02C-1199 — the `SessionAPI` class in `plugins/module_utils/session_utils.py` had an insecure fallback default of `False` for `validate_certs`.

## Root Cause

Line 148 used `module_params.get("validate_certs", False)`. When `validate_certs` is not provided, the value propagated to `open_url` (line 256) with `validate_certs=False`, disabling SSL certificate verification for direct consumers of `SessionAPI`.

## Changed

- `plugins/module_utils/session_utils.py:148`
  - Changed `module_params.get("validate_certs", False)` to `module_params.get("validate_certs", True)`
- `plugins/module_utils/session_utils.py:135-136`
  - Updated docstring to state the default is `True`

## Validation

- Syntax check passed
- Ran `dellemc.openmanage.idrac_session` in check mode against iDRAC `100.68.135.10` (`idrac-W406113`) with `validate_certs=true` and `ca_path` set to `/tmp/idrac-100.68.135.10-ca.pem`. The module successfully reached the iDRAC and returned `"Changes found to be applied."`

## Breaking Changes

This is a security fix. Users who previously relied on the implicit `validate_certs=False` (not passing the parameter) will now need to explicitly set `validate_certs=False` or provide a proper `ca_path`.