### PR TITLE
[ECS02C-1202]: Escape XML attribute and text values in xml_data_conversion

### DIFF
--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -64,6 +64,7 @@ import time
 from datetime import datetime
 from inspect import getfullargspec
 import re
+from xml.sax.saxutils import escape, quoteattr
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.urls import ConnectionError, SSLValidationError
 from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
@@ -540,14 +541,13 @@ def get_current_time(redfish_obj):
 
 
 def xml_data_conversion(attr_dict, fqdd=None, custom_payload_to_add=None):
-    component = """<Component FQDD="{0}">{1}</Component>"""
     attr = ""
     for k, v in attr_dict.items():
         key = re.sub(r"\.(?!\d)", "#", k)
-        attr += '<Attribute Name="{0}">{1}</Attribute>'.format(key, v)
+        attr += '<Attribute Name={0}>{1}</Attribute>'.format(quoteattr(key), escape(str(v)))
     if custom_payload_to_add:
         attr += custom_payload_to_add
-    root = component.format(fqdd, attr)
+    root = '<Component FQDD={0}>{1}</Component>'.format(quoteattr(str(fqdd)), attr)
     return root
 
 

--- a/plugins/modules/idrac_attributes.py
+++ b/plugins/modules/idrac_attributes.py
@@ -302,6 +302,7 @@ error_info:
 
 import json
 import re
+from xml.sax.saxutils import escape, quoteattr
 from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
 from ansible.module_utils.urls import ConnectionError
 from ansible_collections.dellemc.openmanage.plugins.module_utils.idrac_redfish import iDRACRedfishAPI, IdracAnsibleModule
@@ -321,14 +322,13 @@ JOB_URI = "/redfish/v1/Managers/{manager_id}/Jobs/{job_id}"
 
 
 def xml_data_conversion(attrbite, fqdd=None):
-    component = """<Component FQDD="{0}">{1}</Component>"""
     attr = ""
     json_data = {}
     for k, v in attrbite.items():
         key = re.sub(r"\.(?!\d)", "#", k)
-        attr += '<Attribute Name="{0}">{1}</Attribute>'.format(key, v)
+        attr += '<Attribute Name={0}>{1}</Attribute>'.format(quoteattr(key), escape(str(v)))
         json_data[key] = str(v)
-    root = component.format(fqdd, attr)
+    root = '<Component FQDD={0}>{1}</Component>'.format(quoteattr(str(fqdd)), attr)
     return root, json_data
 
 


### PR DESCRIPTION
Fixes ECS02C-1202.

Changed files:
- plugins/module_utils/utils.py
- plugins/modules/idrac_attributes.py

Unit-test run: 3292 passed, 3 failed, 5 errors (all failures/errors isolated to tests/unit/plugins/modules/test_idrac_firmware.py).