### PR TITLE
Replace wrong apply_timeout by apply_time

### DIFF
--- a/docs/modules/redfish_storage_volume.rst
+++ b/docs/modules/redfish_storage_volume.rst
@@ -166,7 +166,7 @@ Parameters
   reboot_server (optional, bool, False)
     Reboot the server to apply the changes.
 
-    :emphasis:`reboot\_server` is applicable only when :emphasis:`apply\_timeout` is :literal:`OnReset` or when the default value for the apply time of the controller is :literal:`OnReset`.
+    :emphasis:`reboot\_server` is applicable only when :emphasis:`apply\_time` is :literal:`OnReset` or when the default value for the apply time of the controller is :literal:`OnReset`.
 
 
   force_reboot (optional, bool, False)


### PR DESCRIPTION
# Description
Same as #1115: fix wrong apply_timeout parameter

# ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
redfish_storage_volume

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility